### PR TITLE
bump version and improve rolling updates

### DIFF
--- a/roles/ingress-nginx/defaults/main.yml
+++ b/roles/ingress-nginx/defaults/main.yml
@@ -1,7 +1,7 @@
 nginx_name: ingress-nginx
 nginx_namespace: ingress-nginx
 kubeconfig: "~/.kube/config"
-chart_version: 2.16.0
+chart_version: 3.20.1
 
 loadBalancerSourceRanges: ["0.0.0.0/0"]
 
@@ -15,4 +15,9 @@ nginx_config:
       use-forwarded-headers: "true"
     tcp: {}
     udp: {}
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 5; /usr/local/openresty/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
+    terminationGracePeriodSeconds: 600
 

--- a/roles/ingress-nginx/defaults/main.yml
+++ b/roles/ingress-nginx/defaults/main.yml
@@ -18,6 +18,6 @@ nginx_config:
     lifecycle:
       preStop:
         exec:
-          command: ["/bin/sh", "-c", "sleep 5; /usr/local/openresty/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
+          command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
 


### PR DESCRIPTION
- Bump ingress nginx chart to 3.20.1 which bump nginx version to 0.43.0
- Update helm values to remove downtime for rolling updates