### PR TITLE
fix default admin user in sitedefault

### DIFF
--- a/examples/sitedefault.yaml
+++ b/examples/sitedefault.yaml
@@ -22,6 +22,5 @@ config:
             objectFilter: (objectClass=inetOrgPerson)
             searchFilter: uid={0}
         sas.logon.initial.password: Password123
-    identities:
         sas.identities:
             administrator: viya_admin

--- a/roles/vdm/files/sitedefault.yaml
+++ b/roles/vdm/files/sitedefault.yaml
@@ -22,6 +22,5 @@ config:
             objectFilter: (objectClass=inetOrgPerson)
             searchFilter: uid={0}
         sas.logon.initial.password: Password123
-    identities:
         sas.identities:
             administrator: viya_admin


### PR DESCRIPTION
sitedefaults.yaml was incorrectly formatted for default admin user. 

Ref SR: [SAS 7613388319]

(was)
```
application:
    identities:
        sas.identities:
            administrator: viya_admin
```

(corrected)
```
application:
    sas.identities:
        administrator: viya_admin

```