### PR TITLE
pick up user-provided license file

### DIFF
--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -79,3 +79,14 @@
     - install
     - uninstall
     - update
+
+- name: assets - Copy user-provided license file
+  copy:
+    src: "{{ V4_CFG_LICENSE}}"
+    dest: "{{ DEPLOY_DIR }}/site-config/license.jwt"
+  when:
+    - V4_CFG_LICENSE is not none
+  tags:
+    - install
+    - uninstall
+    - update


### PR DESCRIPTION
fixes IAC-319

to test:
specify assets and license file using 
V4_CFG_DEPLOYMENT_ASSETS|V4_CFG_LICENSE
and alternatively with the corresponding docker mounts.
- ideally, use a filename other than license.jwt
- make sure NOT to set V4_CFG_SAS_API_KEY|SECRET. It should not be needed of both deployment assets and license are provided