### PR TITLE
Update ansible-vars-iac.yaml to include Postgres

### DIFF
--- a/examples/ansible-vars-iac.yaml
+++ b/examples/ansible-vars-iac.yaml
@@ -23,6 +23,9 @@ V4_CFG_INGRESS_FQDN: <desired_fqdn>
 V4_CFG_TLS_MODE: "full-stack" # [full-stack|front-door|disabled]
 
 ## Postgres
+V4_CFG_POSTGRES_SERVERS:
+  default:
+    internal: true
 
 ## LDAP
 V4_CFG_EMBEDDED_LDAP_ENABLE: true


### PR DESCRIPTION
Per [CONFIG-VARS.md#postgres](https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md#postgres), `V4_CFG_POSTGRES_SERVERS` is required. 

Adding an `internal: true` example configuration to `ansible-vars-iac.yaml`