### PR TITLE
add selector to exclude storageClassName patch from some StatefulSets 

### DIFF
--- a/roles/vdm/templates/transformers/sas-storageclass.yaml
+++ b/roles/vdm/templates/transformers/sas-storageclass.yaml
@@ -23,4 +23,4 @@ patch: |-
 target:
   group: apps
   kind: StatefulSet
-  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search sas-workload-orchestrator)
+  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search,sas-workload-orchestrator)

--- a/roles/vdm/templates/transformers/sas-storageclass.yaml
+++ b/roles/vdm/templates/transformers/sas-storageclass.yaml
@@ -23,3 +23,4 @@ patch: |-
 target:
   group: apps
   kind: StatefulSet
+  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search sas-workload-orchestrator)


### PR DESCRIPTION
make sure that StatefulSets that have no volumeClaimTemplates do not get the sas-ss-storageclass overlay.

fixes #126
fixes #121 

tested by successfully deploying order with both Risk Management and SWO.