### PR TITLE
(IAC-383) Fixed Logging and monitoring in a K8s 1.22 deployment

### DIFF
--- a/roles/monitoring/templates/user-values-elasticsearch-open.yaml
+++ b/roles/monitoring/templates/user-values-elasticsearch-open.yaml
@@ -4,8 +4,11 @@ kibana:
     nodePort: null
   ingress:
     annotations:
+      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     enabled: true
+    # ingressClassName is not currently supported by the Open Distro helm chart
+    # ingressClassName: nginx
     path: /
     hosts:
     - {{ V4M_KIBANA_FQDN }}
@@ -25,7 +28,10 @@ elasticsearch:
     ingress:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+        kubernetes.io/ingress.class: nginx
       enabled: true
+      # ingressClassName is not currently supported by the Open Distro helm chart
+      # ingressClassName: nginx
       path: /
       hosts:
       - {{ V4M_ELASTICSEARCH_FQDN }}

--- a/roles/monitoring/templates/user-values-prom-operator.yaml
+++ b/roles/monitoring/templates/user-values-prom-operator.yaml
@@ -10,6 +10,7 @@ prometheus:
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     enabled: true
+    ingressClassName: nginx
     tls:
     - hosts:
       - {{ V4M_PROMETHEUS_FQDN }}
@@ -31,6 +32,7 @@ alertmanager:
   # Define host-based ingress
   ingress:
     enabled: true
+    ingressClassName: nginx
     tls:
     - hosts:
       - {{ V4M_ALERTMANAGER_FQDN }}
@@ -55,6 +57,7 @@ grafana:
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
       # nginx.ingress.kubernetes.io/rewrite-target: "/grafana"
     enabled: true
+    ingressClassName: nginx
     tls:
     - hosts:
       - {{ V4M_GRAFANA_FQDN }}


### PR DESCRIPTION
### Fixed Logging and monitoring in a K8s 1.22 deployment.:
- Updated the annotations required for logging and monitoring to work with K8s v1.22
### Test coverage:
- Verified the changes on Azure with
    - K8s v1.22.4 and INGRESS_NGINX_CHART_VERSION: 4.0.13
    - K8s v1.19.13 and INGRESS_NGINX_CHART_VERSION: 3.20.1
- Verified the changes on GCP with
    - K8s 1.22.3-gke.700 with INGRESS_NGINX_CHART_VERSION: 4.0.13