### PR TITLE
(IAC-418) Add Support For ingress-only TLS Mode

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -183,7 +183,7 @@ Viya 4 supports 2 different types of certificate generators, Cert-manager and op
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | cert-manager | false | Supported values: [`cert-manager`,`openssl`]. | viya, cluster-logging, cluster-monitoring |
-| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca | all |
+| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`ingress-only`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |
 | V4_CFG_TLS_TRUSTED_CA_CERTS | Path to directory containing only PEM encoded trusted CA certificates files | string | | false | Required when V4_CFG_TLS_CERT is specified. Must include all the CAs in the trust chain for V4_CFG_TLS_CERT. Can be used with or without V4_CFG_TLS_CERT to specify any additionally trusted CAs  | viya |

--- a/examples/ansible-vars-iac.yaml
+++ b/examples/ansible-vars-iac.yaml
@@ -20,7 +20,7 @@ V4_CFG_CR_PASSWORD: <container_registry_password>
 ## Ingress
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_FQDN: <desired_fqdn>
-V4_CFG_TLS_MODE: "full-stack" # [full-stack|front-door|disabled]
+V4_CFG_TLS_MODE: "full-stack" # [full-stack|front-door|ingress-only|disabled]
 
 ## Postgres
 

--- a/examples/ansible-vars.yaml
+++ b/examples/ansible-vars.yaml
@@ -30,7 +30,7 @@ V4_CFG_CR_PASSWORD: <container_registry_password>
 ## Ingress
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_FQDN: <desired_fqdn>
-V4_CFG_TLS_MODE: "full-stack" # [full-stack|front-door|disabled]
+V4_CFG_TLS_MODE: "full-stack" # [full-stack|front-door|ingress-only|disabled]
 
 ## Postgres
 V4_CFG_POSTGRES_SERVERS:

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -1,4 +1,4 @@
-V4_CFG_TLS_MODE: "full-stack" # other valid values are front-door and disabled
+V4_CFG_TLS_MODE: "full-stack" # other valid values are front-door, ingress-only, and disabled
 V4_CFG_RWX_FILESTORE_ENDPOINT: /export
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_MODE: public

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -32,7 +32,7 @@ V4_CFG_DEPLOYMENT_URL_PORT: null
 V4_CFG_INGRESS_FQDN: null
 V4_CFG_INGRESS_TYPE: ingress
 
-V4_CFG_TLS_MODE: "front-door" # other valid values are full-stack and disabled
+V4_CFG_TLS_MODE: "front-door" # other valid values are full-stack, ingress-only, and disabled
 V4_CFG_TLS_CERT: null
 V4_CFG_TLS_KEY: null
 V4_CFG_TLS_TRUSTED_CA_CERTS: null

--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -96,6 +96,21 @@
     - uninstall
     - update
 
+- name: tls - Ingress-only TLS
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { components: "components/security/core/ingress-only-tls", min: "2021.2.4" }
+      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/front-door-tls", min: "2021.2.4" }
+  when:
+    - V4_CFG_TLS_MODE == "ingress-only"
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: tls - Truststores only
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"


### PR DESCRIPTION
Adds support for the ingress-only TLS Mode which will be available starting in 2021.2.4.

Testing:
Performed a full installation (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) to a GCP 1.22.4-gke.1501 & 1.21.6-gke.1500 clusters with the new ingress-only option which resulted in a successful deployment. Verified the ingress type using Gary K's script (see IAC-418 for more details. 