### PR TITLE
(IAC-418) Update ingress-only TLS Mode Task

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -183,7 +183,7 @@ Viya 4 supports 2 different types of certificate generators, Cert-manager and op
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | cert-manager | false | Supported values: [`cert-manager`,`openssl`]. | viya, cluster-logging, cluster-monitoring |
-| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`ingress-only`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. `ingress-only` is only supported on cadence version 2021.2.4 and above. | all |
+| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`ingress-only`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. `ingress-only` is only supported on cadence versions 2021.2.4 and above. | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |
 | V4_CFG_TLS_TRUSTED_CA_CERTS | Path to directory containing only PEM encoded trusted CA certificates files | string | | false | Required when V4_CFG_TLS_CERT is specified. Must include all the CAs in the trust chain for V4_CFG_TLS_CERT. Can be used with or without V4_CFG_TLS_CERT to specify any additionally trusted CAs  | viya |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -183,7 +183,7 @@ Viya 4 supports 2 different types of certificate generators, Cert-manager and op
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | cert-manager | false | Supported values: [`cert-manager`,`openssl`]. | viya, cluster-logging, cluster-monitoring |
-| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`ingress-only`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca | all |
+| V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`ingress-only`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. `ingress-only` is only supported on cadence version 2021.2.4 and above. | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |
 | V4_CFG_TLS_TRUSTED_CA_CERTS | Path to directory containing only PEM encoded trusted CA certificates files | string | | false | Required when V4_CFG_TLS_CERT is specified. Must include all the CAs in the trust chain for V4_CFG_TLS_CERT. Can be used with or without V4_CFG_TLS_CERT to specify any additionally trusted CAs  | viya |

--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -96,6 +96,18 @@
     - uninstall
     - update
 
+- name: tls - Ingress-only TLS - check cadence
+  ansible.builtin.fail:
+    msg: "V4_CFG_TLS_MODE=ingress-only is not supported for cadences older than 2021.2.4"
+  when:
+    - V4_CFG_TLS_MODE == "ingress-only"
+    - V4_CFG_CADENCE_VERSION is version('2021.2.4', "<")
+    - V4_CFG_CADENCE_NAME != "fast"
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: tls - Ingress-only TLS
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"


### PR DESCRIPTION
changes: added a check for cadence, if below 2021.2.4 & using  ingress-only will quit the playbook early with a meaningful error message.
doc: Add note that ingress-only TLS mode is supported for cadence versions 2021.2.4+

testing:
Performed deployments with ingress-only TLS for various cadences to make sure the task was performing correctly. GCP 1.22.6-gke.300 cluster 
stable: 2021.2.3: task correctly quits the playbook early
stable: 2021.2.4: ingress-only is accepted, the deployment starts
lts: 2021.2: task correctly quits the playbook early
fast: ingress-only is accepted, the deployment starts