### PR TITLE
(IAC-445) (IAC-444) Update Ingress-ngnix version and apply CVE Mitigation

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -306,8 +306,8 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | INGRESS_NGINX_NAMESPACE | ingress-nginx helm install namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | ingress-nginx helm chart url | string | https://kubernetes.github.io/ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | ingress-nginx helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.20.1 will be used for K8s clusters whose version is <= 1.21.X and version 4.0.13 will be used for K8s clusters whose version is >= 1.22.X| baseline |
-| INGRESS_NGINX_CONFIG | ingress-nginx helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
+| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 will be used for K8s clusters whose version is <= 1.21.X and version 4.0.13 will be used for K8s clusters whose version is >= 1.22.X| baseline |
+| INGRESS_NGINX_CONFIG | ingress-nginx helm values | string | see [here](../roles/baseline/defaults/main.yml) Altering this value will affect the cluster | false | | baseline |
 
 ### Metrics Server
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -54,6 +54,9 @@ INGRESS_NGINX_CONFIG:
 
     config:
       use-forwarded-headers: "true"
+      allow-snippet-annotations: "true"
+      large-client-header-buffers: "4 32k"
+      annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
     tcp: {}
     udp: {}
     lifecycle:
@@ -61,16 +64,6 @@ INGRESS_NGINX_CONFIG:
         exec:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
-
-# Ingress-nginx - CVE-2021-25742 Mitigation
-INGRESS_NGINX_CVE_PATCH:
-  controller:
-    config:
-      allow-snippet-annotations: "true"
-      large-client-header-buffers: "4 32k"
-      use-forwarded-headers: "true"
-      annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
-
 
 ## Nfs-subdir-external-provisioner
 NFS_CLIENT_NAME: nfs-subdir-external-provisioner

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -30,8 +30,8 @@ ingressVersions:
   k8sMinorVersionCeiling:
     value: 21
     api:
-      chartVersion: 3.20.1
-      appVersion: 0.43.0
+      chartVersion: 3.40.0
+      appVersion: 0.50.0
   k8sMinorVersionFloor:
     value: 22
     api:
@@ -61,6 +61,16 @@ INGRESS_NGINX_CONFIG:
         exec:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
+
+# Ingress-nginx - CVE-2021-25742 Mitigation
+INGRESS_NGINX_CVE_PATCH:
+  controller:
+    config:
+      allow-snippet-annotations: "true"
+      large-client-header-buffers: "4 32k"
+      use-forwarded-headers: "true"
+      annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
+
 
 ## Nfs-subdir-external-provisioner
 NFS_CLIENT_NAME: nfs-subdir-external-provisioner

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,21 +28,6 @@
     - install
     - update
 
-- name: Apply Mitagation for CVE-2021-25742
-  block:
-    - name: Retreive K8s cluster information
-      community.kubernetes.k8s_cluster_info:
-        kubeconfig: "{{ KUBECONFIG }}"
-      register: cluster_info
-    - name: Update INGRESS_NGINX_CONFIG
-      set_fact:
-        INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_CVE_PATCH, recursive=True)}}"
-      when:
-        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersionFloor.value, 'ge')
-  tags:
-    - install
-    - update
-
 - name: Deploy ingress-nginx
   community.kubernetes.helm:
     name: "{{ INGRESS_NGINX_NAME }}"

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,6 +28,21 @@
     - install
     - update
 
+- name: Apply Mitagation for CVE-2021-25742
+  block:
+    - name: Retreive K8s cluster information
+      community.kubernetes.k8s_cluster_info:
+        kubeconfig: "{{ KUBECONFIG }}"
+      register: cluster_info
+    - name: Update INGRESS_NGINX_CONFIG
+      set_fact:
+        INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_CVE_PATCH, recursive=True)}}"
+      when:
+        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersionFloor.value, 'ge')
+  tags:
+    - install
+    - update
+
 - name: Deploy ingress-nginx
   community.kubernetes.helm:
     name: "{{ INGRESS_NGINX_NAME }}"


### PR DESCRIPTION
## Changes

- (IAC-444) This change updates the default ingress-nginx installed on K8s clusters whose version is <= 1.21.X to version 3.40.0 (appVersion 0.50.0)
- (IAC-445) Also included in this PR is a task that will apply a patch to the ingress-nginx helm chart to mitigate [CVE-2021-25742](https://nvd.nist.gov/vuln/detail/CVE-2021-25742). This patch will automatically be applied to all deployments on clusters whose  version is >= 1.22.X

## Tests

### Testing For IAC-444:

1. GKE 1.22.4-gke.1501 Cluster
Ran viya4-deployment with a fast:2020 order, all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
ingress-nginx appVersion 1.1.0 was installed. 

2.  GKE 1.21.6-gke.1503 Cluster
Ran viya4-deployment with a fast:2020 order, all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
ingress-nginx appVersion 0.50.0 was installed. 



### Testing for IAC-445

1.  GKE 1.22.4-gke.1501 Cluster
Ran viya4-deployment with all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
ingress-nginx appVersion 1.1.0 was installed.
The ingress-nginx-controller configmap was present with required configuration data for the mitigation 

```yaml
data:
  allow-snippet-annotations: "true"
  annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\
  large-client-header-buffers: 4 32k
  use-forwarded-headers: "true"
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: ingress-nginx
    meta.helm.sh/release-namespace: ingress-nginx
  creationTimestamp: "2022-03-07T16:22:09Z"
  labels:
    app.kubernetes.io/component: controller
    app.kubernetes.io/instance: ingress-nginx
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/version: 1.1.0
    helm.sh/chart: ingress-nginx-4.0.13
  name: ingress-nginx-controller
  namespace: ingress-nginx
  resourceVersion: "26329"
  uid: cb1660de-fbce-42cf-bb8c-8e4d2410b3a0
```
  
2. GKE 1.21.6-gke.1503 Cluster
Ran viya4-deployment with all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
Verified that the patch was not applied.
ingress-nginx appVersion 0.50.0 was installed. 

### Re-Testing for IAC-445 (After Latest Updates)
1.  GKE 1.22.4-gke.1501 Cluster
Ran viya4-deployment with all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
ingress-nginx appVersion 1.1.0 was installed.
The ingress-nginx-controller configmap was present with required configuration data for the mitigation 

  
2. EKS 1.21 Cluster
Ran viya4-deployment with all tasks set to install without specifying INGRESS_NGINX_CHART_VERSION (baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install) and waited for Viya, Kibana, & Grafana to stabilize and become usable
ingress-nginx appVersion 0.50.0 was installed. 
The ingress-nginx-controller configmap was present with required configuration data for the mitigation 