### PR TITLE
(IAC-478) Dependencies mismatch to viya4-monitoring-kubernetes

### DIFF
--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ SOURCE | NAME | VERSION
 ~ | docker | any
 ~ | git | any
 ~ | kustomize | 3.7.0
-~ | kubectl | 1.20+
+~ | kubectl | 1.20 - 1.22
 ~ | AWS IAM Authenticator | 1.18.9/2020-11-02
 ~ | Helm | 3
 pip3 | ansible | 2.10.7

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ SOURCE | NAME | VERSION
 ~ | docker | any
 ~ | git | any
 ~ | kustomize | 3.7.0
-~ | kubectl | 1.19.9
+~ | kubectl | 1.20+
 ~ | AWS IAM Authenticator | 1.18.9/2020-11-02
 ~ | Helm | 3
 pip3 | ansible | 2.10.7


### PR DESCRIPTION
Updated kubectl version in Dependencies.md from 1.19.9 to a range 1.20 -1.22 to match the viya4-monitoring-kubernetes expected kubectl version.
Test:
- Created Azure cluster with default kubernetes_version: 1.21.7. Viya4 deployment along with logging and monitoring was successful, no issues found in the process.