### PR TITLE
(IAC-376) Use Private Jump IP if Public not Present in tfstate

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -106,6 +106,13 @@
       when:
         - tfstate.jump_public_ip is defined
         - tfstate.jump_public_ip.value|length > 0
+    - name: tfstate - jump server private
+      set_fact:
+        JUMP_SVR_HOST: "{{ tfstate.jump_private_ip.value }}"
+      when:
+        - tfstate.jump_private_ip is defined
+        - tfstate.jump_private_ip.value|length > 0
+        - JUMP_SVR_HOST is not defined
     - name: tfstate - jump user
       set_fact:
         JUMP_SVR_USER: "{{ tfstate.jump_admin_username.value }}"


### PR DESCRIPTION
## Changes

If the `jump_public_ip` is not present in the `.tfstate` file (The user opted not to create a public IP associated with the jump box) and `jump_private_ip` is present. Ansible will attempt to use that value for `JUMP_SVR_HOST`

## Tests

Tested in AWS, GCP, and Azure on a 1.21 cluster

1. I first set up my private infrastructure, which includes a bastion host that I will use later to access the jumpbox.
2. Once connected to the bastion host I cloned the IAC project and edited my tfvars to include the following:
    ```
    create_jump_public_ip = false
    create_jump_vm        = true
    ```
    * This ensures when my cluster infrastructure is created my jumpbox will not include a public IP address.
3. I ran terraform apply and waited for my cluster infrastructure to come up.
4. In the `terraform.tfstate` file I ensured that the `jump_public_ip` was not present and the `jump_private_ip` was.
5. From my bastion host I SSHed into the jumpbox and verified that filestore was mounted at `jump_rwx_filestore_path`, in my case `/viya-share`
6. Back on my bastion host I ran ansible plays from the viya4-deployment using the following tags baseline,viya,install
7. SSHing back into the jumpbox I saw that ansible was able to successfully connect to the jumpbox via the private IP and create the directories from `roles/jump-server/tasks/main.yml`
8. The deployment stabilized and notably the `sas-cas-server-default-controller` pod which requires the `data` and `homes` directories from the filestore to be present.
