### PR TITLE
(IAC-483) Conditionally Patch ingress-nginx Config

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -54,9 +54,6 @@ INGRESS_NGINX_CONFIG:
 
     config:
       use-forwarded-headers: "true"
-      allow-snippet-annotations: "true"
-      large-client-header-buffers: "4 32k"
-      annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
     tcp: {}
     udp: {}
     lifecycle:
@@ -64,6 +61,15 @@ INGRESS_NGINX_CONFIG:
         exec:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
+
+# Ingress-nginx - CVE-2021-25742 Mitigation
+INGRESS_NGINX_CVE_2021_25742_PATCH:
+  controller:
+    config:
+      allow-snippet-annotations: "true"
+      large-client-header-buffers: "4 32k"
+      use-forwarded-headers: "true"
+      annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
 
 ## Nfs-subdir-external-provisioner
 NFS_CLIENT_NAME: nfs-subdir-external-provisioner

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,6 +28,23 @@
     - install
     - update
 
+- name: Apply Mitagation for CVE-2021-25742
+  block:
+    - name: Retreive K8s cluster information
+      community.kubernetes.k8s_cluster_info:
+        kubeconfig: "{{ KUBECONFIG }}"
+      register: cluster_info
+    - name: Update INGRESS_NGINX_CONFIG
+      set_fact:
+        INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_CVE_2021_25742_PATCH, recursive=True)}}"
+      when:
+        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersionFloor.value, 'ge')
+        - INGRESS_NGINX_CHART_VERSION is version('4.0.10', ">=") or
+          (INGRESS_NGINX_CHART_VERSION is version('3.40.0', ">=") and INGRESS_NGINX_CHART_VERSION is version('4.0.0', "<"))
+  tags:
+    - install
+    - update
+
 - name: Deploy ingress-nginx
   community.kubernetes.helm:
     name: "{{ INGRESS_NGINX_NAME }}"

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,7 +28,7 @@
     - install
     - update
 
-- name: Apply Mitagation for CVE-2021-25742
+- name: Apply Mitigation for CVE-2021-25742
   block:
     - name: Retreive K8s cluster information
       community.kubernetes.k8s_cluster_info:


### PR DESCRIPTION
### Changes
The mitigation will be applied by default for K8s clusters whose version is >=1.22.x
and whose ingress-ngnix version is >=1.1.0 or (>=0.50.0 and <1.0.0, for the updated legacy versions of nginx that support this CVE).

### Tests
Performed deployments in AKS on both 1.22.6 & 1.21.9 clusters to see the CVE mitigation patch behavior. All deployments in this table resulted in a healthy Viya deployment.

| Cadence  | K8s Version | Ingress-Nginx Version                      | Was CVE Mitigation Applied by Default |
|----------|-------------|--------------------------------------------|---------------------------------------|
| 2021.2.5 | 1.22.6      | 1.1.0                                      | Yes                                   |
| 2021.2.4 | 1.22.6      | 1.1.0                                      | Yes                                   |
| 2021.2.5 | 1.22.6      | 1.1.1 (Custom INGRESS_NGINX_CHART_VERSION) | Yes                                   |
| Fast R/S | 1.22.6      | 1.1.0                                      | Yes                                   |
| 2021.2.4 | 1.21.9      | 0.50.0                                     | No                                    |
| 2021.2.2 | 1.21.9      | 0.50.0                                     | No                                    |
| 2021.2   | 1.21.9      | 0.50.0                                     | No                                    |

































































