### PR TITLE
(IAC-525) Update to handle new SAS_CERTIFICATE_GENERATOR default.

### DIFF
--- a/roles/vdm/templates/generators/customer-provided-merge-sas-certframe-configmap.yaml
+++ b/roles/vdm/templates/generators/customer-provided-merge-sas-certframe-configmap.yaml
@@ -14,4 +14,6 @@ literals:
 - SAS_CERTIFICATE_ADDITIONAL_SAN_IP={{ V4_CFG_TLS_ADDITIONAL_SAN_IP }}
 {% if V4_CFG_TLS_GENERATOR == "openssl" %}
 - SAS_CERTIFICATE_GENERATOR=openssl
+{% elif V4_CFG_TLS_GENERATOR == "cert-manager"%}
+- SAS_CERTIFICATE_GENERATOR=cert-manager
 {% endif -%}

--- a/roles/vdm/templates/generators/customer-provided-merge-sas-certframe-configmap.yaml
+++ b/roles/vdm/templates/generators/customer-provided-merge-sas-certframe-configmap.yaml
@@ -14,6 +14,6 @@ literals:
 - SAS_CERTIFICATE_ADDITIONAL_SAN_IP={{ V4_CFG_TLS_ADDITIONAL_SAN_IP }}
 {% if V4_CFG_TLS_GENERATOR == "openssl" %}
 - SAS_CERTIFICATE_GENERATOR=openssl
-{% elif V4_CFG_TLS_GENERATOR == "cert-manager"%}
+{% elif V4_CFG_TLS_GENERATOR == "cert-manager" %}
 - SAS_CERTIFICATE_GENERATOR=cert-manager
 {% endif -%}


### PR DESCRIPTION
# Changes
Update the `customer-provided-merge-sas-certframe-configmap.yaml` jinja template to handle the new default value for `SAS_CERTIFICATE_GENERATOR` starting in 2021.2.6.
This change makes it so that `SAS_CERTIFICATE_GENERATOR` is set based off the value the user defines for `V4_CFG_TLS_GENERATOR`, rather than falling back to the default.

# Tests
1. Performed a 2021.2.6 deployment in a 1.22.6 AKS Cluster. Set `V4_CFG_TLS_GENERATOR:cert-manager` and the resulting deployment was successful. Cert-manager was used as the cert generator.
2. Performed a 2021.2.6 deployment in a 1.22.6 AKS Cluster. Set `V4_CFG_TLS_GENERATOR:openssl` as well as the required  variables `V4_CFG_TLS_CERT, V4_CFG_TLS_KEY, V4_CFG_TLS_TRUSTED_CA_CERTS` and the resulting deployment was successful. openssl was used as the cert generator.

Note: Documentation coming in a separate ticket.
