### PR TITLE
(IAC-525) update ansible task for certificate configuration

### DIFF
--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -192,22 +192,35 @@
     - uninstall
     - update
 
-- name: tls - Certificate Generation
+- name: tls - Certificate Generation - cert-manager
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
       - { transformers: "cert-manager-provided-ingress-certificate.yaml", vdm: true, priority: 70 }
-      - { generators: "customer-provided-merge-sas-certframe-configmap.yaml", vdm: true }
   when:
     - V4_CFG_TLS_MODE != "disabled"
-    - (V4_CFG_TLS_CERT is none and V4_CFG_TLS_KEY is none and V4_CFG_TLS_GENERATOR == "cert-manager") or V4_CFG_TLS_GENERATOR == "openssl"
+    - (V4_CFG_TLS_CERT is none and V4_CFG_TLS_KEY is none and V4_CFG_TLS_GENERATOR == "cert-manager")
   tags:
     - install
     - uninstall
     - update
 
+- name: tls - Configuring Certificate Attributes
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { generators: "customer-provided-merge-sas-certframe-configmap.yaml", vdm: true }
+  when:
+    - V4_CFG_TLS_MODE != "disabled"
+    - (V4_CFG_TLS_GENERATOR == "cert-manager" or V4_CFG_TLS_GENERATOR == "openssl")
+  tags:
+    - install
+    - uninstall
+    - update
 
 - name: tls - Consul UI
   overlay_facts:


### PR DESCRIPTION
## Changes
Update `roles/vdm/tasks/tls.yaml` to correctly apply `cert-manager-provided-ingress-certificate.yaml`. It should only be used if the `V4_CFG_TLS_GENERATOR` is set to cert-manager and the TLS key and Cert are not provided by the user.

Update the customer-provided-merge-sas-certframe-configmap.yaml so that it is correctly applied. It should be used when `V4_CFG_TLS_GENERATOR` is either openssl or cert-manager.