### PR TITLE
(IAC-518) Update Default CERT_MANAGER_CHART_VERSION to 1.7.2

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -282,7 +282,7 @@ V4_CFG_POSTGRES_SERVERS:
 | CERT_MANAGER_NAMESPACE | cert-manager helm install namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager helm chart url | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager helm chart name | string | cert-manager| false | | baseline |
-| CERT_MANAGER_CHART_VERSION | cert-manager helm chart version | string | 1.6.1 | false | | baseline |
+| CERT_MANAGER_CHART_VERSION | cert-manager helm chart version | string | 1.7.2 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
 
 ### Cluster Autoscaler

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -9,7 +9,7 @@ CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
-CERT_MANAGER_CHART_VERSION: 1.6.1
+CERT_MANAGER_CHART_VERSION: 1.7.2
 CERT_MANAGER_CONFIG: 
   installCRDs: "true"
   extraArgs:


### PR DESCRIPTION
### Changes
Since our current default version of cert-manager has reached EOL, we are updating the default version to 1.7.2 which is currently supported.
https://cert-manager.io/docs/installation/supported-releases/

Currently supported Viya 4 releases should be compatible with this new default version.
https://go.documentation.sas.com/doc/en/itopscdc/v_026/itopssr/n18dxcft030ccfn1ws2mujww1fav.htm#p0bskqphz9np1ln14ejql9ush824

### Tests

The following scenarios were tested and showed expected behavior:
| Cadence | CERT\_MANAGER\_CHART\_VERSION | Cloud Provider | K8s Version | TLS Mode | Customer\-Provided\|cert\-manager\-Generated Ingress Certificates  |
|---|---|---|---|---|---|
| 2021\.2\.6 | 1\.7\.2 | GCP | 1\.22\.6\-gke\.1000 | full\-stack | Customer Provided  |
| 2021\.2\.6 | 1\.7\.2 | GCP | 1\.22\.6\-gke\.1000 | front\-door | cert\-manager\-Generated  |
| 2021\.2\.5 | 1\.7\.2 | Azure | 1\.21\.7 | front\-door | Customer Provided  |
| 2021\.2\.5 | 1\.7\.2 | Azure | 1\.21\.7 | full\-stack | cert\-manager\-Generated  |
| 2021\.2 | 1\.7\.2 | GCP | 1\.19\.16\-gke\.11000 | full\-stack | Customer Provided  |
| 2021\.2 | 1\.7\.2 | GCP | 1\.19\.16\-gke\.11000 | front\-door | cert\-manager\-Generated  |