### PR TITLE
(IAC-540) support for openssl certificate generator with openssl-generated ingress certificates

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -178,7 +178,7 @@ When setting V4_CFG_MANAGE_STORAGE to true, A new storage classes will be create
 
 ## TLS
 
-Viya 4 supports 2 different types of certificate generators, Cert-manager and openssl. When using the openssl certificate generator, you must provide: V4_CFG_TLS_CERT, V4_CFG_TLS_KEY, V4_CFG_TLS_TRUSTED_CA_CERTS. Also, the openssl certificate generator cannot be used in conjunction with the viya4-monitoring-kubernetes stack.
+Viya 4 supports 2 different types of certificate generators, Cert-manager and openssl. The openssl certificate generator cannot be used in conjunction with the viya4-monitoring-kubernetes stack.
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -193,9 +193,9 @@ Viya 4 supports 2 different types of certificate generators, Cert-manager and op
 
 Notes:
 
-*Values can be use to configure the tls generator when V4_CFG_TLS_MODE is not set to `disabled` and one of the following conditions is met.*
+*Values can be used to configure the tls generator when V4_CFG_TLS_MODE is not set to `disabled` and one of the following conditions is met.*
   - V4_CFG_TLS_GENERATOR is set to `cert-manager` and no V4_CFG_TLS_CERT/V4_CFG_TLS_KEY are defined
-  - V4_CFG_TLS_GENERATOR is set to `openssl`
+  - V4_CFG_TLS_GENERATOR is set to `openssl` and no V4_CFG_TLS_CERT/V4_CFG_TLS_KEY are defined
 
 ## Postgres
 

--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -5,11 +5,13 @@
 # See sas-bases/examples/security/README.md for full details
 - name: tls - openssl-generator check
   fail:
-    msg: "When using openssl-generator and V4_CFG_TLS_MODE is not 'disabled' you must provide: V4_CFG_TLS_CERT, V4_CFG_TLS_KEY, V4_CFG_TLS_TRUSTED_CA_CERTS"
+    msg: "When using openssl-generator, and V4_CFG_TLS_MODE is not 'disabled', and your V4_CFG_CADENCE_VERSION is <= 2021.1, you must provide: V4_CFG_TLS_CERT, V4_CFG_TLS_KEY, V4_CFG_TLS_TRUSTED_CA_CERTS"
   when:
     - V4_CFG_TLS_MODE != "disabled"
     - V4_CFG_TLS_GENERATOR == "openssl"
     - V4_CFG_TLS_CERT is none or V4_CFG_TLS_KEY is none or V4_CFG_TLS_TRUSTED_CA_CERTS is none
+    - V4_CFG_CADENCE_VERSION is version('2021.1', "<=")
+    - V4_CFG_CADENCE_NAME != "fast"
   tags:
     - install
     - uninstall
@@ -205,6 +207,20 @@
   tags:
     - install
     - uninstall
+    - update
+
+- name: tls - Certificate Generation - openssl
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { resources: "openssl-generated-ingress-certificate.yaml", vdm: true, min: "2021.2" }
+  when:
+    - V4_CFG_TLS_MODE != "disabled"
+    - (V4_CFG_TLS_CERT is none and V4_CFG_TLS_KEY is none and V4_CFG_TLS_GENERATOR == "openssl")
+  tags:
+    - install
     - update
 
 - name: tls - Configuring Certificate Attributes

--- a/roles/vdm/templates/resources/openssl-generated-ingress-certificate.yaml
+++ b/roles/vdm/templates/resources/openssl-generated-ingress-certificate.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    sas.com/admin: namespace
+  name: sas-create-openssl-ingress-certificate
+spec:
+  template:
+    spec:
+      imagePullSecrets: []
+      containers:
+      - env:
+        - name: KUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+# The following lines are optional and should only be set if you want to exclude SAN DNS or IP entries from the ingress controller certificate that are included on back-end server certificates
+{% if V4_CFG_TLS_ADDITIONAL_SAN_DNS|length %}
+        - name: SAS_CERTIFICATE_ADDITIONAL_SAN_DNS
+          value: "{{ V4_CFG_TLS_ADDITIONAL_SAN_DNS }}"
+{% endif %}
+{% if V4_CFG_TLS_ADDITIONAL_SAN_IP|length %}
+        - name: SAS_CERTIFICATE_ADDITIONAL_SAN_IP
+          value: "{{ V4_CFG_TLS_ADDITIONAL_SAN_IP }}"
+{% endif %}
+        - name: SAS_CERTIFICATE_COMMON_NAME
+          value: sas-viya-openssl-ingress-certificate
+        - name: SAS_CERTFRAME_TOKEN_DIR
+          value: /certframe-token
+        - name: SAS_CERTIFICATE_SECRET_NAME
+          value: sas-ingress-certificate
+        - name: SAS_CERTIFICATE_GENERATOR
+          value: openssl
+        - name: SAS_CERTIFICATE_FILE_FORMAT
+          value: pem
+        - name: SAS_CERTIFICATE_CA_CERTIFICATE_FILE
+          value: /security/ca.crt
+        - name: SAS_CERTIFICATE_FILE
+          value: /security/tls.crt
+        - name: SAS_CERTIFICATE_PRIVATE_KEY_FILE
+          value: /security/tls.key
+        - name: SAS_CERTIFICATE_EXCLUDE_POD_OWNERREF
+          value: "true"
+        envFrom:
+        - configMapRef:
+            name: sas-certframe-user-config
+        image: sas-certframe
+        imagePullPolicy: IfNotPresent
+        name: sas-certframe
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /certframe-token
+          name: certframe-token
+        - mountPath: /security
+          name: security
+      restartPolicy: OnFailure
+      volumes:
+      - name: certframe-token
+        secret:
+          defaultMode: 420
+          secretName: sas-certframe-token
+      - emptyDir: {}
+        name: security


### PR DESCRIPTION
### Changes
Adds support for openssl certificate generator with openssl-generated ingress certificates
See: https://go.documentation.sas.com/doc/en/sasadmincdc/v_026/calencryptmotion/n1xdqv1sezyrahn17erzcunxwix9.htm#p05udr35umjxfrn1xftq9i29bbdk

### Tests
Verified that the current supported cadence range works with this new addition. See (IAC-540) for more test details.
