### PR TITLE
(IAC-565) Update Default INGRESS_NGINX_CHART_VERSION for 1.22.x+ clusters

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -306,7 +306,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | INGRESS_NGINX_NAMESPACE | ingress-nginx helm install namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | ingress-nginx helm chart url | string | https://kubernetes.github.io/ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | ingress-nginx helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 will be used for K8s clusters whose version is <= 1.21.X and version 4.0.13 will be used for K8s clusters whose version is >= 1.22.X| baseline |
+| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 will be used for K8s clusters whose version is <= 1.21.X and version 4.0.17 will be used for K8s clusters whose version is >= 1.22.X| baseline |
 | INGRESS_NGINX_CONFIG | ingress-nginx helm values | string | see [here](../roles/baseline/defaults/main.yml) Altering this value will affect the cluster | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -35,8 +35,8 @@ ingressVersions:
   k8sMinorVersionFloor:
     value: 22
     api:
-      chartVersion: 4.0.13
-      appVersion: 1.1.0
+      chartVersion: 4.0.17
+      appVersion: 1.1.1
 
 ## Ingress-nginx - Ingress
 INGRESS_NGINX_NAME: ingress-nginx


### PR DESCRIPTION
## Changes

Since Viya will be supporting 1.21, 1.22, and 1.23 in June, the default `INGRESS_NGINX_CHART_VERSION` version that gets installed when the cluster K8s version is >= 1.22.x is being changed to 4.0.17 (app version v1.1.1). The updated ingress-nginx version adds support for 1.23 while still retaining support for 1.22. 

The default `INGRESS_NGINX_CHART_VERSION` for clusters with K8s version is <= 1.21.x remains unchanged and the user is still able to set their own overriding value for `INGRESS_NGINX_CHART_VERSION`.

See: https://github.com/kubernetes/ingress-nginx/#support-versions-table


## Tests

Test summary, more detail is present in the internal ticket.

| Cloud Provider | kubectl version | K8s Version      | Cadence   | Ingress-nginx version | Deployment Stabilized |
|----------------|-----------------|------------------|-----------|-----------------------|-----------------------|
| GCP            | 1.22.10         | 1.22.9-gke.1500  | Fast:2020 | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.22.9-gke.1500  | 2022.1.1  | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.23.6-gke.1700  | Fast:2020 | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.21.11-gke.1100 | 2021.2    | v0.50.0               | Yes                   |
| Azure          | 1.22.10         | 1.22.6           | Fast:2020 | v1.1.1                | Yes                   |
| Azure          | 1.22.10         | 1.22.6           | 2022.1.1  | v1.1.1                | Yes                   |
| Azure          | 1.22.10         | 1.23.5           | Fast:2020 | v1.1.1                | Yes                   |
| Azure          | 1.22.10         | 1.21.9           | 2021.2    | v0.50.0               | Yes                   |
| AWS            | 1.22.10         | 1.22             | Fast:2020 | v1.1.1                | Yes                   |
| AWS            | 1.22.10         | 1.22             | 2021.2.6  | v1.1.1                | Yes                   |