### PR TITLE
(IAC-553) move to kubectl 1.22.10 to support k8s 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ ENV HOME=/viya4-deployment
 RUN pip install -r ./requirements.txt \
   && ansible-galaxy install -r ./requirements.yaml \
   && chmod -R g=u /etc/passwd /etc/group /viya4-deployment/ \
-  && chmod 755 /viya4-deployment/docker-entrypoint.sh
+  && chmod 755 /viya4-deployment/docker-entrypoint.sh \
+  && git config --system --add safe.directory /viya4-deployment
 
 ENV PLAYBOOK=playbook.yaml
 ENV VIYA4_DEPLOYMENT_TOOLING=docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt upgrade -y \
 
 FROM baseline as tool_builder
 ARG kustomize_version=3.7.0
-ARG kubectl_version=1.21.8
+ARG kubectl_version=1.22.10
 
 WORKDIR /build
 
@@ -16,12 +16,14 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 
 # Installation
 FROM baseline
+ARG HELM_VERSION=3.8.1
 ARG aws_cli_version=2.1.20
 ARG gcp_cli_version=334.0.0
 
 # Add extra packages
 RUN apt install -y gzip wget git git-lfs jq sshpass \
-  && curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash \
+  && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
+  && ./get-helm-3 --version v$HELM_VERSION --no-sudo \
   && helm plugin install https://github.com/databus23/helm-diff \
   # AWS
   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${aws_cli_version}.zip" -o "awscliv2.zip" \
@@ -45,8 +47,7 @@ ENV HOME=/viya4-deployment
 RUN pip install -r ./requirements.txt \
   && ansible-galaxy install -r ./requirements.yaml \
   && chmod -R g=u /etc/passwd /etc/group /viya4-deployment/ \
-  && chmod 755 /viya4-deployment/docker-entrypoint.sh \
-  && git config --system --add safe.directory /viya4-deployment
+  && chmod 755 /viya4-deployment/docker-entrypoint.sh
 
 ENV PLAYBOOK=playbook.yaml
 ENV VIYA4_DEPLOYMENT_TOOLING=docker

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ SOURCE | NAME | VERSION
 ~ | docker | any
 ~ | git | any
 ~ | kustomize | 3.7.0
-~ | kubectl | 1.20 - 1.22
+~ | kubectl | 1.21 - 1.23
 ~ | AWS IAM Authenticator | 1.18.9/2020-11-02
 ~ | Helm | 3
 pip3 | ansible | 2.10.7


### PR DESCRIPTION
## Changes
Because Viya will support K8s 1.21, 1.22 and 1.23 in June 2022, the version of kubectl needs to be bumped up to 1.22 so that it will be in the required -1/+1 range for supported versions of K8s.
## Tests

|Cloud Provider|kubectl version|K8s version|Cadence|Deployment Stabilized|
|-------|-------|------|-----|------|
|Azure|1.22.10|1.21.9|Fast:2020|Yes|
|Azure|1.22.10|1.21.7|Fast:2020|Yes|
|Azure|1.22.10|1.22.6|Fast:2020|Yes|
|Azure|1.22.10|1.23.5|Fast:2020|Yes|
|AWS|1.22.10|1.22.9|Fast:2020|InProgress |