### PR TITLE
Add logic to Download viya4-orders-cli task

### DIFF
--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -5,6 +5,8 @@
     url: "https://github.com/sassoftware/viya4-orders-cli/releases/download/{{ V4_ORDERS_CLI_VERSION }}/viya4-orders-cli_{{ hostvars[inventory_hostname]['ansible_system']|lower }}_amd64"
     dest: "{{ tmpdir.path }}/viya4-orders-cli"
     mode: "0755"
+  when:
+    - V4_CFG_LICENSE is none or V4_CFG_DEPLOYMENT_ASSETS is none
   tags:
     - install
     - uninstall


### PR DESCRIPTION
Added some conditional logic to assets.yaml so that the viya4-orders-cli is only pulled when required (i.e. when either deployment assets or a license have not been provided in ansible-vars.yaml).