### PR TITLE
(IAC-617) Wrong variable is being defaulted to /export

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -1,5 +1,5 @@
 V4_CFG_TLS_MODE: "full-stack" # other valid values are front-door, ingress-only, and disabled
-V4_CFG_RWX_FILESTORE_ENDPOINT: /export
+V4_CFG_RWX_FILESTORE_PATH: /export
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_MODE: public
 


### PR DESCRIPTION
The baseline role currently defaults V4_CFG_RWX_FILESTORE_ENDPOINT to /export; this is almost certainly meant to be V4_CFG_RWX_FILESTORE_PATH (same as the VDM role).