### PR TITLE
fix: (IAC-586) Correct the ingress-nginx annotations

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -50,7 +50,7 @@ INGRESS_NGINX_CONFIG:
       externalTrafficPolicy: Local
       sessionAffinity: None
       loadBalancerSourceRanges: "{{ LOADBALANCER_SOURCE_RANGES |default(['0.0.0.0/0'], -1) }}"
-      annotation:
+      annotations:
 
     config:
       use-forwarded-headers: "true"


### PR DESCRIPTION
## Changes
Fix the default `INGRESS_NGINX_CONFIG` so that `annotation` is now correctly `annotations`

## Tests
More details and artifacts in the internal ticket
#### Summary
1. Created a private cluster using the IAC code and ensured `V4_CFG_INGRESS_MODE` would be set to "private" before running viya4-deployment
2. I adjusted private_ingress annotation variable for azure to include an additional annotation for testing, to mimic the issue reported in IAC-586
    * https://github.com/sassoftware/viya4-deployment/blob/main/roles/baseline/defaults/main.yml#L133-L137
4. Ran baseline,install and verified that the ingress-nginx-controller service object correctly contained both of my annotations (proxy-buffering & azure-load-balancer-internal)

```bash
jumpuser@jarpat-pr-byo-jump-vm:/opt/viya4-deployment$ kubectl get service -n ingress-nginx ingress-nginx-controller -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: ingress-nginx
    meta.helm.sh/release-namespace: ingress-nginx
    nginx.ingress.kubernetes.io/proxy-buffering: "on"
    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
...truncated
```