### PR TITLE
feat: (IAC-620) Update deploy command to use CRD server-side apply

### DIFF
--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -13,7 +13,7 @@
 
 - name: prereqs - cluster-api
   ansible.builtin.shell: |
-    kubectl --kubeconfig {{ KUBECONFIG }} apply -n {{ NAMESPACE }} --selector="sas.com/admin=cluster-api" -f {{ DEPLOY_DIR }}/site.yaml
+    kubectl --kubeconfig {{ KUBECONFIG }} apply -n {{ NAMESPACE }} --selector="sas.com/admin=cluster-api" --server-side --force-conflicts -f {{ DEPLOY_DIR }}/site.yaml
     kubectl --kubeconfig {{ KUBECONFIG }} wait --for condition=established --timeout=60s -l "sas.com/admin=cluster-api" crd
   register: result
   failed_when:


### PR DESCRIPTION
# Changes
The Viya install steps are being updated in 2022.1.3. The “sas.com/admin=cluster-api” kubectl apply command now includes additional arguments "--server-side --force-conflicts"

# Tests
See internal IAC-620 ticket