### PR TITLE
fix: (IAC-630) Fix the V4_CFG_CADENCE_NAME conditionals in the Postgres Task

### DIFF
--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -52,7 +52,7 @@
         - not internal_postgres
   when:
     - V4_CFG_CADENCE_VERSION is version('2021.1.4', "<")
-    - V4_CFG_CADENCE_NAME != "fast"
+    - V4_CFG_CADENCE_NAME|lower != "fast"
   tags:
     - install
     - uninstall
@@ -86,7 +86,7 @@
         internal: "{{ internal_postgres }}"
       with_dict: "{{ V4_CFG_POSTGRES_SERVERS }}"
   when:
-    - V4_CFG_CADENCE_VERSION is version('2021.1.4', ">=") or V4_CFG_CADENCE_NAME == "fast"
+    - V4_CFG_CADENCE_VERSION is version('2021.1.4', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
   tags:
     - install
     - uninstall


### PR DESCRIPTION
## Changes
For the conditionals that check that `V4_CFG_CADENCE_NAME` in `roles/vdm/tasks/postgres/postgres.yaml`, it should be case-insensitive.

## Tests
| Scenario | Cloud | K8s Version      | Postgres Type | V4\_CFG\_CADENCE\_VERSION | V4\_CFG\_CADENCE\_NAME | Deployment Status |
| -------- | ----- | ---------------- | ------------- | ------------------------- | ---------------------- | ----------------- |
| 1        | Azure | v1.22.6          | external      | 2020                      | FAST                   | stabilized        |
| 2        | Azure | v1.22.6          | external      | 2020                      | fast                   | stabilized        |
| 3        | GCP   | v1.22.9-gke.1500 | internal      | 2020                      | FAST                   | stabilized        |
| 4        | GCP   | v1.22.9-gke.1500 | internal      | 2020                      | fast                   | stabilized        |