### PR TITLE
feat: (IAC-568) remove kibanaserver, logcollector and metricgetter id/passwords from "cluster-logging - output credentials" task

### DIFF
--- a/roles/monitoring/tasks/cluster-logging.yaml
+++ b/roles/monitoring/tasks/cluster-logging.yaml
@@ -47,9 +47,6 @@
     msg:
       - "OpenSearch admin  - username: admin,                   password: {{ V4M_KIBANA_PASSWORD }}"
       - "OpenSearch admin  - username: logadm,                  password: {{ V4M_KIBANA_LOGADM_PASSWORD }}"
-      - "OpenSearch Dashboards Server - username: kibanaserver, password: {{ V4M_KIBANASERVER_PASSWORD }}"
-      - "Log Collector - username: logcollector,                password: {{ V4M_LOGCOLLECTOR_PASSWORD }}"
-      - "Metric Getter - username: metricgetter,                password: {{ V4M_METRICGETTER_PASSWORD }}"
   tags:
     - install
 


### PR DESCRIPTION
# Change:
Removed the kibanaserver, logcollector and metricgetter credentials from "cluster-logging - output credentials" task

# Test:
- Ran 'cluster-logging, install' task, verified the above credentials were not present as part of output credentials task.
See internal ticket for more details.