### PR TITLE
fix: (IAC-645) Updated CAS transformer templates for CAS workers and backup

### DIFF
--- a/roles/vdm/templates/transformers/cas-manage-backup.yaml
+++ b/roles/vdm/templates/transformers/cas-manage-backup.yaml
@@ -13,6 +13,10 @@ patch: |-
 target:
   group: viya.sas.com
   kind: CASDeployment
+  # Uncomment this to apply to all CAS servers:
   name: .*
+  # Uncomment this to apply to one particular named CAS server:
+  #name: { NAME-OF-SERVER }
+  # Uncomment this to apply to the default CAS server:
+  labelSelector: "sas.com/cas-server-default"
   version: v1alpha1
-

--- a/roles/vdm/templates/transformers/cas-manage-workers.yaml
+++ b/roles/vdm/templates/transformers/cas-manage-workers.yaml
@@ -1,3 +1,5 @@
+# This block of code is for specifying the number of workers in an MPP
+# deployment. Do not use this block for SMP deployments. The default value is 2
 ---
 apiVersion: builtin
 kind: PatchTransformer
@@ -11,5 +13,10 @@ patch: |-
 target:
   group: viya.sas.com
   kind: CASDeployment
+  # Uncomment this to apply to all CAS servers:
   name: .*
+  # Uncomment this to apply to one particular named CAS server:
+  #name: { NAME-OF-SERVER }
+  # Uncomment this to apply to the default CAS server:
+  labelSelector: "sas.com/cas-server-default"
   version: v1alpha1


### PR DESCRIPTION
# Changes:
CAS transformers for workers and backup used for default CAS (provider's) are targeting "All" CASDeployments.  For MT deployment, the values in the provider's CAS transformers overwrite the values for tenants' CAS during kustomization ignoring the user specified values for tenants' CAS.
The stale files cas-manage-workers.yaml and cas-manage-backup.yaml were updated to use latest CAS changes.

# Tests:
Deployments were successful for all the scenarios with expected number of workers and backup controllers. See internal ticket for details.
- Multi-tenant MPP deployment with 2 workers and backup controller -> Onboard ACME tenant with 1 worker and 0 backup controller
- (Extended scenario1) Multi-tenant MPP deployment with 2 workers and 1 backup controller -> Onboard ACME tenant with 1 worker and 0 backup  controller --> onboard another tenant INTECH with 0 worker and 1 backup controller
- Multi-tenant MPP deployment with 2 workers and backup controller -> Onboard ACME tenant with 2 worker and 1 backup controller
- Non Multi-tenant MPP deployment with 3 workers and 1 backup controller