### PR TITLE
feat: (IAC-564) SAS Viya Startup Sequencer - Add entry in kustomization.yaml

### DIFF
--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -45,6 +45,7 @@
       - { resources: "base", priority: 0 }
       - { resources: "overlays/update-checker" }
       - { configurations: "overlays/required/kustomizeconfig.yaml", priority: 51 }
+      - { transformers: "overlays/startup/ordered-startup-transformer.yaml", priority: 59 }
       - { transformers: "overlays/required/transformers.yaml", priority: 60 }
       - { generators: "sas-license.yaml", vdm: true }
       - { generators: "sas-shared-config.yaml", vdm: true }


### PR DESCRIPTION
# Changes:
Enabled the startup sequencer feature by referencing the overlay "sas-bases/overlays/startup/ordered-startup-transformer.yaml " in the transformers section of kustomization.yaml before the line that includes "sas-bases/overlays/required/transformers.yaml".

# Test:
See internal ticket for details. Performed two deployments one with small VA order and another large NA order. Both deployments had stabilization times improved.