### PR TITLE
feat: (IAC-629) Support SingleStore (DAC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This project contains Ansible code that creates a baseline cluster in an existin
 - SAS Viya Multi-tenant Deployment
   - Multi-tenancy in SAS Viya creates and manages separate and secure cloud-computing units. See [SAS Viya Multi-Tenancy Documentation](./docs/user/Multi-Tenancy.md) for details.
 
+- SAS Viya SingleStore Deployment
+  - SingleStore is a cloud-native database designed for data-intensive applications. See [SAS Viya SingleStore Documentation](./docs/user/SingleStore.md) for details.
+
 ## Prerequisites
 
 Use of these tools requires operational knowledge of the following technologies: 

--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -1,0 +1,27 @@
+# SAS Viya Support for SingleStore
+
+SAS Viya supports SingleStore. SingleStore is a cloud-native database designed for data-intensive applications. A distributed, relational, SQL database management system that features ANSI SQL support, it is known for speed in data ingest, transaction processing, and query processing. 
+
+## Requirements for a SingleStore SAS Viya deployment
+
+If your SAS software order included SAS Viya with SingleStore, there are additional requirements that may apply to your deployment. The SAS Viya _IT Operations Guide_ provides detailed information about requirements for a SingleStore enabled deployment of SAS Viya. Access it [here](https://documentation.sas.com/doc/en/itopscdc/default/itopssr/n0jq6u1duu7sqnn13cwzecyt475u.htm#n0qs42c42o8jjzn12ib4276fk7pb)
+
+## Deploying SingleStore with SAS Viya Deployment
+
+You can deploy SAS Viya with SingleStore into a Kubernetes cluster that is running in Microsoft Azure. The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/singlestore/examples/sample-input-singlestore.tfvars) for terraform configuration values that create an Azure cluster suitable for deploying Viya and SingleStore to.
+
+## Customizing SingleStore Deployment Overlays
+
+Refer to the SAS Viya Deployment instructions [Getting Started](https://github.com/sassoftware/viya4-deployment#getting-started) and the [SAS Viya Customizations](https://github.com/sassoftware/viya4-deployment#sas-viya-customizations) section for information on how users can make changes to their deployment by adding custom overlays into subfolders under the `/site-config` folder.
+
+After running SAS Viya Deployment with the setting DEPLOY=false in your ansible-vars.yaml file, locate the `sas-bases/` folder which is a peer to the `site-config/` folder underneath your deployments <base_dir>.
+
+Follow each step under the `SingleStore Cluster Definition` heading in the `sas-bases/examples/sas-singlestore/README.md` file to configure your SingleStore deployment noting the exceptions below:
+
+Add the new Step 1a after Step 1.
+
+1a. Copy `$deploy/sas-bases/components/sas-singlestore` into `$deploy/site-config/sas-singlestore/component`.
+
+Skip Step 3.  The SAS Viya Deployment playbook will automatically add the SingleStore component and overlays to the base kustomization.yaml file that you have copied to `site-config/` and edited per the README.md file steps.
+
+After completing the README.md steps for SingleStore, set DEPLOY=true in your ansible-vars.yaml file and run SAS Viya Deployment with the "viya, install" tags to deploy Viya with SingleStore into your cluster.

--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -8,7 +8,7 @@ If your SAS software order included SAS Viya with SingleStore, there are additio
 
 ## Deploying SingleStore with SAS Viya Deployment
 
-You can deploy SAS Viya with SingleStore into a Kubernetes cluster that is running in Microsoft Azure. The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/singlestore/examples/sample-input-singlestore.tfvars) for terraform configuration values that create an Azure cluster suitable for deploying Viya and SingleStore to.
+You can deploy SAS Viya with SingleStore into a Kubernetes cluster that is running in Microsoft Azure. The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for terraform configuration values that create an Azure cluster suitable for deploying Viya and SingleStore to.
 
 ## Customizing SingleStore Deployment Overlays
 

--- a/roles/vdm/library/siteconfig_info.py
+++ b/roles/vdm/library/siteconfig_info.py
@@ -62,7 +62,7 @@ class siteConfig(object):
           yamlblock = yaml.safe_load(file)
           # handle components
           if "kind" in yamlblock and yamlblock['kind'] == "Component":
-            self.add_overlays(Overlay.COMPONENT, kustomizefilefullpath)
+            self.add_overlays(Overlay.COMPONENT, folder)
           else:
             # handle kustomization
             self.add_overlays(Overlay.RESOURCE, folder)

--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -72,8 +72,8 @@
       - { transformers: "overlays/network/ingress/security/transformers/ingress-tls-transformers.yaml", max: "2021.1.2", priority: 51 }
       - { transformers: "overlays/network/ingress/security/transformers/product-tls-transformers.yaml", max: "2021.1.2", priority: 51 }
       - { transformers: "overlays/network/ingress/security/transformers/backend-tls-transformers.yaml", max: "2021.1.2", priority: 51 }
-      - { components: "components/security/core/base/full-stack-tls", min: "2021.1.3" }
-      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/full-stack-tls", min: "2021.1.3" }
+      - { components: "components/security/core/base/full-stack-tls", min: "2021.1.3", priority: 51 }
+      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/full-stack-tls", min: "2021.1.3", priority: 51 }
   when:
     - V4_CFG_TLS_MODE == "full-stack"
   tags:
@@ -89,8 +89,8 @@
     add:
       - { transformers: "overlays/network/ingress/security/transformers/cas-connect-tls-transformers.yaml", max: "2021.1.2", priority: 51 }
       - { transformers: "overlays/network/ingress/security/transformers/ingress-tls-transformers.yaml", max: "2021.1.2", priority: 51 }
-      - { components: "components/security/core/base/front-door-tls", min: "2021.1.3" }
-      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/front-door-tls", min: "2021.1.3" }
+      - { components: "components/security/core/base/front-door-tls", min: "2021.1.3", priority: 51 }
+      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/front-door-tls", min: "2021.1.3", priority: 51 }
   when:
     - V4_CFG_TLS_MODE == "front-door"
   tags:
@@ -116,8 +116,8 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { components: "components/security/core/ingress-only-tls", min: "2021.2.4" }
-      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/front-door-tls", min: "2021.2.4" }
+      - { components: "components/security/core/ingress-only-tls", min: "2021.2.4", priority: 51 }
+      - { components: "components/security/network/networking.k8s.io/ingress/nginx.ingress.kubernetes.io/front-door-tls", min: "2021.2.4", priority: 51 }
   when:
     - V4_CFG_TLS_MODE == "ingress-only"
   tags:
@@ -132,7 +132,7 @@
     existing: "{{ vdm_overlays }}"
     add:
       - { transformers: "overlays/network/ingress/security/transformers/truststore-transformers-without-backend-tls.yaml", max: "2021.1.2", priority: 51 }
-      - { components: "components/security/core/base/truststores-only", min: "2021.1.3" }
+      - { components: "components/security/core/base/truststores-only", min: "2021.1.3", priority: 51 }
   when:
     - V4_CFG_TLS_MODE == "disabled"
     - V4_CFG_TLS_TRUSTED_CA_CERTS is not none

--- a/roles/vdm/templates/kustomization.yaml
+++ b/roles/vdm/templates/kustomization.yaml
@@ -25,4 +25,12 @@ namespace: {{ NAMESPACE }}
 {% endif %}
 
 {% endfor %}
-
+{% if "components" not in ordered_overlays.result %}
+{% if "components" in user_customizations.overlays %}
+components:
+## user defined components
+{% for item in user_customizations.overlays['components']|sort %}
+  - {{ item }}
+{% endfor %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Add SingleStore README and siteconfig_info change
- Add a link to SingleStore requirements in SAS Viya Operations Guide 2022.1.4
- Add a link to SingleStore README from base README.md to expose it to DAC consumers
- Add additional step and step to skip for sas-bases/examples/sas-singlestore/README.md
- update siteconfig_info to use folder name instead of full path to kustomization.yaml file for component entries