### PR TITLE
Added ability to append custom definitions to kustomization.yaml.

### DIFF
--- a/roles/vdm/library/siteconfig_info.py
+++ b/roles/vdm/library/siteconfig_info.py
@@ -96,6 +96,12 @@ class siteConfig(object):
     for yamlfile in yamlfiles:
       self.addResource(yamlfile)
 
+  def add_customkustomize_block(self, folder):
+    if os.path.exists(os.path.join(folder, "customkustomize.yaml")):
+      kustomizeCustomfilefullpath = os.path.join(folder, "customkustomize.yaml")
+      with open(kustomizeCustomfilefullpath) as file:
+        self._overlays['customkustomize']  = file.read()
+
 def main():
   fields = {
     "path": {"required": True, "type": "str"},
@@ -111,6 +117,9 @@ def main():
       for exclude in module.params['exclude']:
         if folder == exclude:
           skip = True
+      if folder == "customkustomize":
+        sc.add_customkustomize_block(os.path.join(scFolder, folder))
+        skip = True
       if not skip:
         sc.traverse(os.path.join(scFolder, folder))
     module.exit_json(changed=True, overlays=sc.get_overlays())

--- a/roles/vdm/templates/kustomization.yaml
+++ b/roles/vdm/templates/kustomization.yaml
@@ -26,3 +26,6 @@ namespace: {{ NAMESPACE }}
 
 {% endfor %}
 
+{% if 'customkustomize' in user_customizations.overlays %}
+{{ user_customizations.overlays['customkustomize'] }}
+{% endif %}


### PR DESCRIPTION
To solve the issue with SASWORK location and similar customizations, I made some changes to allow for a custom block to be added to the end of kustomization.yaml.

This fixes #223

Instructions:

1. Add a folder "customkustomize" to `<cluster>/<namespace>/site-config/`
2. Add the files you want to put in the kustomization.yaml file that's not under "resources" to this new folder
3. Add a file "customkustomize.yaml" to that folder which contains exactly what you want to append in the resulting kustomization.yaml file.

The end result can for example look like this:
```
$ ls site-config/customkustomize/
change-viya-volume-storage-class.yaml  customkustomize.yaml
$ cat site-config/customkustomize/customkustomize.yaml
patches:
  - path: site-config/customkustomize/change-viya-volume-storage-class.yaml
    target:
      kind: PodTemplate
      labelSelector: "sas.com/template-intent=sas-launcher"
```