### PR TITLE
(IAC-658): fix: Updating default value for V4MT_TENANT_CAS_CUSTOMIZATION

### DIFF
--- a/roles/multi-tenancy/defaults/main.yml
+++ b/roles/multi-tenancy/defaults/main.yml
@@ -17,7 +17,7 @@ V4MT_TENANT_IDS: null
 V4MT_PROVIDER_PASSWORD: null
 
 # CAS customization values
-V4MT_TENANT_CAS_CUSTOMIZATION: null
+V4MT_TENANT_CAS_CUSTOMIZATION: {}
 
 # Setting values for retry and delay to 60 seconds for Onboard and Offboard job
 V4MT_ONBOARD_RETRY: 60

--- a/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
@@ -137,7 +137,7 @@
   with_dict: "{{ V4MT_TENANT_CAS_CUSTOMIZATION }}"
   when: 
     - V4MT_ENABLE
-    - V4MT_TENANT_CAS_CUSTOMIZATION is defined
+    - V4MT_TENANT_CAS_CUSTOMIZATION is not none
   tags:
     - onboard
 
@@ -148,6 +148,6 @@
     cmd: "{{ DEPLOY_DIR }}/site-config/create-cas-server.sh --tenant {{ item }} \
          --output {{ DEPLOY_DIR }}/site-config --workers 0 --backup 0"
   with_items: '{{ V4MT_TENANT_IDS.split(",") | replace(" ", "") | lower }}'
-  when: (V4MT_TENANT_CAS_CUSTOMIZATION is undefined) or (item not in (V4MT_TENANT_CAS_CUSTOMIZATION.keys()| lower))
+  when: item not in (V4MT_TENANT_CAS_CUSTOMIZATION.keys()| lower)
   tags:
     - onboard


### PR DESCRIPTION
Originally the default value for V4MT_TENANT_CAS_CUSTOMIZATION was set as null. However, ansible treats 'null' as a valid value for dictionary being defined and tries to run dictionary operations.

# Change: 
Updated the default value for V4MT_TENANT_CAS_CUSTOMIZATION as a empty dictionary.

# Tests:
This specific issue was hit when V4MT_TENANT_CAS_CUSTOMIZATION wasn't provided and ansible used the null value as default.
- Verified with the default changed, the issue was not seen. 
- Ran other combinations with V4MT_TENANT_CAS_CUSTOMIZATION only defined for two out three tenants
- Also verified when V4MT_TENANT_CAS_CUSTOMIZATION  is defined with only tenant names but no customizations.