### PR TITLE
fix: (IAC-670) Correct case typo for alertmanagerSpec

### DIFF
--- a/roles/monitoring/templates/user-values-prom-operator.yaml
+++ b/roles/monitoring/templates/user-values-prom-operator.yaml
@@ -39,7 +39,7 @@ alertmanager:
       secretName: alertmanager-ingress-tls-secret
     hosts:
     - {{ V4M_ALERTMANAGER_FQDN  }}
-  alertManagerSpec:
+  alertmanagerSpec:
     externalUrl: "https://{{ V4M_ALERTMANAGER_FQDN }}"
     storage:
       volumeClaimTemplate:


### PR DESCRIPTION
A yaml heading (alertManagerSpec) for alert manager didn't match the resource definition heading for alert manager in the helm chart used to deploy it. That mismatch resulted in the V4M_STORAGECLASS configuration variable setting being ignored for alert manager.