### PR TITLE
feat: (IAC-673): DAC - support K8s 1.24 deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt upgrade -y \
 
 FROM baseline as tool_builder
 ARG kustomize_version=3.7.0
-ARG kubectl_version=1.22.10
+ARG kubectl_version=1.23.8
 
 WORKDIR /build
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ SOURCE | NAME | VERSION
 ~ | docker | any
 ~ | git | any
 ~ | kustomize | 3.7.0
-~ | kubectl | 1.21 - 1.23
+~ | kubectl | 1.22 - 1.24
 ~ | AWS IAM Authenticator | 1.18.9/2020-11-02
 ~ | Helm | 3
 pip3 | ansible | 2.10.7


### PR DESCRIPTION
# Changes:
The default kubectl version value updated to 1.23.8. The supported range is now 1.22x to 1.24x

# Tests:
Deployment was successful for 1.22, 1.23 and 1.24. See the internal ticket for details