### PR TITLE
fix: (IAC-689) add new exclusion for storageclass patch transformer

### DIFF
--- a/roles/vdm/templates/transformers/sas-storageclass.yaml
+++ b/roles/vdm/templates/transformers/sas-storageclass.yaml
@@ -23,4 +23,4 @@ patch: |-
 target:
   group: apps
   kind: StatefulSet
-  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search,sas-workload-orchestrator)
+  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search,sas-workload-orchestrator,sas-data-agent-server-colocated)


### PR DESCRIPTION
Why:

Release testready orders now include the du sas-data-agent-server-colocated
which does not have /spec/VolumeClaimTemplates in its StatefulSet
resulting in fatal kustomize error during DAC execution. Excluding that du
from the patchTransformer as we've done for two other dus earlier.