### PR TITLE
feat: (IAC-687) Upgrade Ingress-nginx to v1.3.0 to support K8s 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt upgrade -y \
 
 FROM baseline as tool_builder
 ARG kustomize_version=3.7.0
-ARG kubectl_version=1.23.8
+ARG kubectl_version=1.24.0
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt upgrade -y \
 
 FROM baseline as tool_builder
 ARG kustomize_version=3.7.0
-ARG kubectl_version=1.24.0
+ARG kubectl_version=1.23.8
 
 WORKDIR /build
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -309,7 +309,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | INGRESS_NGINX_NAMESPACE | ingress-nginx helm install namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | ingress-nginx helm chart url | string | https://kubernetes.github.io/ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | ingress-nginx helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 will be used for K8s clusters whose version is <= 1.21.X and version 4.0.17 will be used for K8s clusters whose version is >= 1.22.X| baseline |
+| INGRESS_NGINX_CHART_VERSION | ingress-nginx helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 will be used for K8s clusters whose version is <= 1.21.X and version 4.2.3 will be used for K8s clusters whose version is >= 1.22.X| baseline |
 | INGRESS_NGINX_CONFIG | ingress-nginx helm values | string | see [here](../roles/baseline/defaults/main.yml) Altering this value will affect the cluster | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -35,8 +35,8 @@ ingressVersions:
   k8sMinorVersionFloor:
     value: 22
     api:
-      chartVersion: 4.0.17
-      appVersion: 1.1.1
+      chartVersion: 4.2.3
+      appVersion: 1.3.0
 
 ## Ingress-nginx - Ingress
 INGRESS_NGINX_NAME: ingress-nginx


### PR DESCRIPTION
# Changes:
To support K8s 1.24, update Ingress NGINX Controller to v1.3.0 (Chart version 4.2.3)

# Tests:
Verified following scenarios, see the internal ticket for details.
1. Viya4 deployment with K8s v1.24.0
2. Viya4 deployment with default K8s v1.23.8