### PR TITLE
feat: (IAC-636) Update cert-manager version 1.9.1

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -285,7 +285,7 @@ V4_CFG_POSTGRES_SERVERS:
 | CERT_MANAGER_NAMESPACE | cert-manager helm install namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager helm chart url | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager helm chart name | string | cert-manager| false | | baseline |
-| CERT_MANAGER_CHART_VERSION | cert-manager helm chart version | string | 1.7.2 | false | | baseline |
+| CERT_MANAGER_CHART_VERSION | cert-manager helm chart version | string | 1.9.1 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
 
 ### Cluster Autoscaler

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -9,7 +9,7 @@ CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
-CERT_MANAGER_CHART_VERSION: 1.7.2
+CERT_MANAGER_CHART_VERSION: 1.9.1
 CERT_MANAGER_CONFIG: 
   installCRDs: "true"
   extraArgs:


### PR DESCRIPTION
### Changes
Update the default `CERT_MANAGER_CHART_VERSION` to 1.9.1 to support K8s 1.24. 
The cert-manager 1.9.x version supports K8s 1.20-1.24 see https://cert-manager.io/docs/installation/supported-releases/.

### Tests
See artifacts in internal ticket.

| Scenario | Order  | Cadence   | CERT_MANAGER_CHART_VERSION | Cloud Provider | K8s Version      | TLS Mode   | Certificates |
|------------|--------|-----------|----------------------------|----------------|------------------|------------|---------------------------------------------------------------|
| 1          | * | fast:2020 | 1.9.1                      | Azure          | 1.23.8           | full-stack | Customer-Provided                                             |
| 2          | *| fast:2020 | 1.9.1                      | GCP            | v1.24.2-gke.1900 | front-door | Customer-Provided                                             |
| 3          | *| fast:2020 | 1.9.1                      | Azure          | 1.23.8           | front-door | cert-manager-Generated                                        |
| 4          | *| fast:2020 | 1.9.1                      | GCP            | v1.24.2-gke.1900 | full-stack | cert-manager-Generated                                        |
| 5          | *| lts:2022.1| 1.9.1                      | GCP            | v1.22.11-gke.400 | full-stack | Customer-Provided                                             |



