### PR TITLE
feat: (IAC-582) Support configuring schedule-start-stop.yaml

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -274,6 +274,8 @@ V4_CFG_POSTGRES_SERVERS:
 | V4_CFG_EMBEDDED_LDAP_ENABLE | Deploy openldap in the namespace for authentication | bool | false | false | [Openldap Config](../roles/vdm/templates/generators/openldap-bootstrap-config.yaml) | viya |
 | V4_CFG_CONSUL_ENABLE_LOADBALANCER | Setup LB to access consul ui | bool | false | false | Consul ui port is 8500 | viya |
 | V4_CFG_ELASTICSEARCH_ENABLE | Enable opendistro search | bool | true | false | When deploying LTS less than 2020.1 or Stable less than 2020.1.2 set to false | viya |
+| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | Must be used in conjunction with `V4_CFG_VIYA_STOP_SCHEDULE` | viya |
+| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | Must be used in conjunction with `V4_CFG_VIYA_START_SCHEDULE` | viya |
 
 ## 3rd Party tools
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -274,8 +274,8 @@ V4_CFG_POSTGRES_SERVERS:
 | V4_CFG_EMBEDDED_LDAP_ENABLE | Deploy openldap in the namespace for authentication | bool | false | false | [Openldap Config](../roles/vdm/templates/generators/openldap-bootstrap-config.yaml) | viya |
 | V4_CFG_CONSUL_ENABLE_LOADBALANCER | Setup LB to access consul ui | bool | false | false | Consul ui port is 8500 | viya |
 | V4_CFG_ELASTICSEARCH_ENABLE | Enable opendistro search | bool | true | false | When deploying LTS less than 2020.1 or Stable less than 2020.1.2 set to false | viya |
-| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | Must be used in conjunction with `V4_CFG_VIYA_STOP_SCHEDULE` | viya |
-| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | Must be used in conjunction with `V4_CFG_VIYA_START_SCHEDULE` | viya |
+| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya start job schedule. Must be used in conjunction with `V4_CFG_VIYA_STOP_SCHEDULE` | viya |
+| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya stop job schedule. Must be used in conjunction with `V4_CFG_VIYA_START_SCHEDULE` | viya |
 
 ## 3rd Party tools
 

--- a/examples/ansible-vars-iac.yaml
+++ b/examples/ansible-vars-iac.yaml
@@ -36,3 +36,9 @@ V4_CFG_CONNECT_ENABLE_LOADBALANCER: false
 ## Monitoring and Logging
 ## uncomment and update the below values when deploying the viya4-monitoring-kubernetes stack
 #V4M_BASE_DOMAIN: <base_domain>
+
+## Viya Start and Stop Schedule
+## uncomment and update the values below with CronJob schedule expressions if you would
+## like to start and stop your Viya Deployment on a schedule
+#V4_CFG_VIYA_START_SCHEDULE: "0 7 * * 1-5"
+#V4_CFG_VIYA_STOP_SCHEDULE: "0 19 * * 1-5"

--- a/examples/ansible-vars.yaml
+++ b/examples/ansible-vars.yaml
@@ -54,3 +54,9 @@ V4_CFG_CONNECT_ENABLE_LOADBALANCER: false
 ## Monitoring and Logging
 ## uncomment and update the below values when deploying the viya4-monitoring-kubernetes stack
 #V4M_BASE_DOMAIN: <base_domain>
+
+## Viya Start and Stop Schedule
+## uncomment and update the values below with CronJob schedule expressions if you would
+## like to start and stop your Viya Deployment on a schedule
+#V4_CFG_VIYA_START_SCHEDULE: "0 7 * * 1-5"
+#V4_CFG_VIYA_STOP_SCHEDULE: "0 19 * * 1-5"

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -52,6 +52,9 @@ V4_CFG_CONNECT_ENABLE_LOADBALANCER: false
 V4_CFG_CONNECT_FQDN: null
 V4_CFG_CLUSTER_NODE_POOL_MODE: "standard"
 
+V4_CFG_VIYA_STOP_SCHEDULE: null
+V4_CFG_VIYA_START_SCHEDULE: null
+
 # In theory the issuer name can be changed; however, there are a few overlays where this value is hard coded. See:
 # - $deploy/sas-bases/overlays/cert-manager-issuer/resources.yaml
 # - $deploy/sas-bases/overlays/network/ingress/security/generators/backend-tls-generators.yaml

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -182,7 +182,6 @@
     - uninstall
     - update
 
-
 - name: Include Kustomize
   include_tasks: kustomize.yaml
   tags:

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -175,6 +175,14 @@
     - uninstall
     - update
 
+- name: Include Start Stop
+  include_tasks: start_stop.yaml
+  tags:
+    - install
+    - uninstall
+    - update
+
+
 - name: Include Kustomize
   include_tasks: kustomize.yaml
   tags:

--- a/roles/vdm/tasks/start_stop.yaml
+++ b/roles/vdm/tasks/start_stop.yaml
@@ -1,7 +1,7 @@
 - name: start_stop - validate cadence version
   ansible.builtin.fail:
     msg: >
-      The schedule-start-stop.yaml transformer is not supported is not supported for cadences 2021.1 and older
+      The schedule-start-stop.yaml transformer is not supported for cadences 2021.1 and older
       
       To continue deploying 2021.1 or older remove 'V4_CFG_VIYA_STOP_SCHEDULE' & 'V4_CFG_VIYA_START_SCHEDULE' from your
       Ansible vars. Alternatively select a newer 'V4_CFG_CADENCE_VERSION' if you would like to use the 

--- a/roles/vdm/tasks/start_stop.yaml
+++ b/roles/vdm/tasks/start_stop.yaml
@@ -1,0 +1,42 @@
+- name: start_stop - validate cadence version
+  ansible.builtin.fail:
+    msg: >
+      The schedule-start-stop.yaml transformer is not supported is not supported for cadences 2021.1 and older
+      
+      To continue deploying 2021.1 or older remove 'V4_CFG_VIYA_STOP_SCHEDULE' & 'V4_CFG_VIYA_START_SCHEDULE' from your
+      Ansible vars. Alternatively selected a newer 'V4_CFG_CADENCE_VERSION' if you would like to use the 
+      schedule-start-stop.yaml transformer
+  when:
+    - V4_CFG_VIYA_STOP_SCHEDULE is not none
+    - V4_CFG_VIYA_START_SCHEDULE is not none
+    - V4_CFG_CADENCE_VERSION is version('2021.1', "<=")
+    - V4_CFG_CADENCE_NAME|lower != "fast"
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: start_stop - validate variables
+  ansible.builtin.fail:
+    msg: >
+      If using the schedule-start-stop.yaml transformer you must defined both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
+  when:
+    - (V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is none) or (V4_CFG_VIYA_STOP_SCHEDULE is none and V4_CFG_VIYA_START_SCHEDULE is not none)
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: start_stop - add transformer
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: "schedule-start-stop.yaml", vdm: true, min: "2021.2", priority: 61 }
+  when:
+    - V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is not none
+  tags:
+    - install
+    - uninstall
+    - update

--- a/roles/vdm/tasks/start_stop.yaml
+++ b/roles/vdm/tasks/start_stop.yaml
@@ -4,7 +4,7 @@
       The schedule-start-stop.yaml transformer is not supported is not supported for cadences 2021.1 and older
       
       To continue deploying 2021.1 or older remove 'V4_CFG_VIYA_STOP_SCHEDULE' & 'V4_CFG_VIYA_START_SCHEDULE' from your
-      Ansible vars. Alternatively selected a newer 'V4_CFG_CADENCE_VERSION' if you would like to use the 
+      Ansible vars. Alternatively select a newer 'V4_CFG_CADENCE_VERSION' if you would like to use the 
       schedule-start-stop.yaml transformer
   when:
     - V4_CFG_VIYA_STOP_SCHEDULE is not none
@@ -19,7 +19,7 @@
 - name: start_stop - validate variables
   ansible.builtin.fail:
     msg: >
-      If using the schedule-start-stop.yaml transformer you must defined both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
+      If using the schedule-start-stop.yaml transformer you must define both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
   when:
     - (V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is none) or (V4_CFG_VIYA_STOP_SCHEDULE is none and V4_CFG_VIYA_START_SCHEDULE is not none)
   tags:

--- a/roles/vdm/templates/transformers/schedule-start-stop.yaml
+++ b/roles/vdm/templates/transformers/schedule-start-stop.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: schedule-stop-all
+patch: |-
+  - op: replace
+    path: /spec/schedule
+    # schedule: MUST BE PROVIDED BY USER.
+    # This is the cron schedule by which the sas-stop-all job is run.
+    # Example:
+    #   value: '0 19 * * 1-5'
+    value: {{ V4_CFG_VIYA_STOP_SCHEDULE }}
+  - op: replace
+    path: /spec/suspend
+    value: false
+  - op: replace
+    path: /metadata/labels/sas.com~1deployment
+    value: 'user-specified'
+target:
+  name: sas-stop-all
+  kind: CronJob
+---
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: schedule-start-all
+patch: |-
+  - op: replace
+    path: /spec/schedule
+    # schedule: MUST BE PROVIDED BY USER.
+    # This is the cron schedule by which the sas-start-all job is run
+    # Example:
+    #   value: '0 7 * * 1-5'
+    value: {{ V4_CFG_VIYA_START_SCHEDULE }}
+  - op: replace
+    path: /spec/suspend
+    value: false
+  - op: replace
+    path: /metadata/labels/sas.com~1deployment
+    value: 'user-specified'
+target:
+  name: sas-start-all
+  kind: CronJob


### PR DESCRIPTION
### Changes

Allow the user to configure and include the schedule-start-stop.yaml transformer using the two new variables `V4_CFG_VIYA_STOP_SCHEDULE` & `V4_CFG_VIYA_START_SCHEDULE`. This configures cronjobs in Kubernetes that will start and stop your Viya deployment using the times you specified for these variables. As per the deployment instructions this transformer is prioritized to be placed after `sas-bases/overlays/required/transformers.yaml` in the kustomization.yaml

### Tests

See internal ticket for more details/artifacts

1. In a 1.23.8 AKS cluster performed a Viya deployment on the latest cadence with `V4_CFG_VIYA_STOP_SCHEDULE: "0 19 * * 1-5"` & `V4_CFG_VIYA_START_SCHEDULE: "30 19 * * 1-5"` set. Verified the positioning of the transformer in the kustomization.yaml. Also verified the Viya deployment successfully stopped at 19:00 UTC and started back up at 19:30 UTC.
2. Input validation scenarios, ensured that `schedule-start-stop.yaml` was only used if using a supported cadence and if both variables are defined.