### PR TITLE
feat: (IAC-582) Allow user to specify either V4_CFG_VIYA_START_SCHEDULE or V4_CFG_VIYA_STOP_SCHEDULE

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -274,8 +274,14 @@ V4_CFG_POSTGRES_SERVERS:
 | V4_CFG_EMBEDDED_LDAP_ENABLE | Deploy openldap in the namespace for authentication | bool | false | false | [Openldap Config](../roles/vdm/templates/generators/openldap-bootstrap-config.yaml) | viya |
 | V4_CFG_CONSUL_ENABLE_LOADBALANCER | Setup LB to access consul ui | bool | false | false | Consul ui port is 8500 | viya |
 | V4_CFG_ELASTICSEARCH_ENABLE | Enable opendistro search | bool | true | false | When deploying LTS less than 2020.1 or Stable less than 2020.1.2 set to false | viya |
-| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya start job schedule. | viya |
-| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya stop job schedule. | viya |
+| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya start job schedule. See note below. | viya |
+| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya stop job schedule. See note below. | viya |
+
+Notes:
+  - With the two Viya scheduling variables, `V4_CFG_VIYA_START_SCHEDULE` and `V4_CFG_VIYA_STOP_SCHEDULE`. If you define one and not the other, it will result in a suspended cronjob for the variable that was not defined.
+    - For example, defining `V4_CFG_VIYA_STOP_SCHEDULE` and not `V4_CFG_VIYA_START_SCHEDULE` will result in a Viya stop job that runs on a schedule and a suspended Viya start job that you will be able to manually trigger.
+  - Defining both `V4_CFG_VIYA_START_SCHEDULE` and `V4_CFG_VIYA_STOP_SCHEDULE` will result in a non-suspended Viya start and stop job that runs on the schedule you defined.
+
 ## 3rd Party tools
 
 ### Cert-manager

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -274,9 +274,8 @@ V4_CFG_POSTGRES_SERVERS:
 | V4_CFG_EMBEDDED_LDAP_ENABLE | Deploy openldap in the namespace for authentication | bool | false | false | [Openldap Config](../roles/vdm/templates/generators/openldap-bootstrap-config.yaml) | viya |
 | V4_CFG_CONSUL_ENABLE_LOADBALANCER | Setup LB to access consul ui | bool | false | false | Consul ui port is 8500 | viya |
 | V4_CFG_ELASTICSEARCH_ENABLE | Enable opendistro search | bool | true | false | When deploying LTS less than 2020.1 or Stable less than 2020.1.2 set to false | viya |
-| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya start job schedule. Must be used in conjunction with `V4_CFG_VIYA_STOP_SCHEDULE` | viya |
-| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya stop job schedule. Must be used in conjunction with `V4_CFG_VIYA_START_SCHEDULE` | viya |
-
+| V4_CFG_VIYA_START_SCHEDULE | Configure your SAS Viya deployment to start on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya start job schedule. | viya |
+| V4_CFG_VIYA_STOP_SCHEDULE | Configure your SAS Viya deployment to stop on specific schedules | string |  | false | This variable accepts [CronJob schedule expressions](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax) to create your Viya stop job schedule. | viya |
 ## 3rd Party tools
 
 ### Cert-manager

--- a/roles/vdm/tasks/start_stop.yaml
+++ b/roles/vdm/tasks/start_stop.yaml
@@ -7,8 +7,7 @@
       Ansible vars. Alternatively select a newer 'V4_CFG_CADENCE_VERSION' if you would like to use the 
       schedule-start-stop.yaml transformer
   when:
-    - V4_CFG_VIYA_STOP_SCHEDULE is not none
-    - V4_CFG_VIYA_START_SCHEDULE is not none
+    - V4_CFG_VIYA_STOP_SCHEDULE is not none or V4_CFG_VIYA_START_SCHEDULE is not none
     - V4_CFG_CADENCE_VERSION is version('2021.1', "<=")
     - V4_CFG_CADENCE_NAME|lower != "fast"
   tags:
@@ -16,16 +15,16 @@
     - uninstall
     - update
 
-- name: start_stop - validate variables
-  ansible.builtin.fail:
-    msg: >
-      If using the schedule-start-stop.yaml transformer you must define both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
-  when:
-    - (V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is none) or (V4_CFG_VIYA_STOP_SCHEDULE is none and V4_CFG_VIYA_START_SCHEDULE is not none)
-  tags:
-    - install
-    - uninstall
-    - update
+#- name: start_stop - validate variables
+#  ansible.builtin.fail:
+#    msg: >
+#      If using the schedule-start-stop.yaml transformer you must define both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
+#  when:
+#    - (V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is none) or (V4_CFG_VIYA_STOP_SCHEDULE is none and V4_CFG_VIYA_START_SCHEDULE is not none)
+#  tags:
+#    - install
+#    - uninstall
+#    - update
 
 - name: start_stop - add transformer
   overlay_facts:
@@ -35,7 +34,7 @@
     add:
       - { transformers: "schedule-start-stop.yaml", vdm: true, min: "2021.2", priority: 61 }
   when:
-    - V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is not none
+    - V4_CFG_VIYA_STOP_SCHEDULE is not none or V4_CFG_VIYA_START_SCHEDULE is not none
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/start_stop.yaml
+++ b/roles/vdm/tasks/start_stop.yaml
@@ -15,17 +15,6 @@
     - uninstall
     - update
 
-#- name: start_stop - validate variables
-#  ansible.builtin.fail:
-#    msg: >
-#      If using the schedule-start-stop.yaml transformer you must define both 'V4_CFG_VIYA_START_SCHEDULE' and 'V4_CFG_VIYA_START_SCHEDULE'
-#  when:
-#    - (V4_CFG_VIYA_STOP_SCHEDULE is not none and V4_CFG_VIYA_START_SCHEDULE is none) or (V4_CFG_VIYA_STOP_SCHEDULE is none and V4_CFG_VIYA_START_SCHEDULE is not none)
-#  tags:
-#    - install
-#    - uninstall
-#    - update
-
 - name: start_stop - add transformer
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"

--- a/roles/vdm/templates/transformers/schedule-start-stop.yaml
+++ b/roles/vdm/templates/transformers/schedule-start-stop.yaml
@@ -20,7 +20,7 @@ patch: |-
 {% if V4_CFG_VIYA_STOP_SCHEDULE is not none %}
     value: false
 {% else %}
-    value: false
+    value: true
 {% endif %}
   - op: replace
     path: /metadata/labels/sas.com~1deployment

--- a/roles/vdm/templates/transformers/schedule-start-stop.yaml
+++ b/roles/vdm/templates/transformers/schedule-start-stop.yaml
@@ -10,10 +10,18 @@ patch: |-
     # This is the cron schedule by which the sas-stop-all job is run.
     # Example:
     #   value: '0 19 * * 1-5'
+{% if V4_CFG_VIYA_STOP_SCHEDULE is not none %}
     value: {{ V4_CFG_VIYA_STOP_SCHEDULE }}
+{% else %}
+    value: '0 19 * * 1-5'
+{% endif %}
   - op: replace
     path: /spec/suspend
+{% if V4_CFG_VIYA_STOP_SCHEDULE is not none %}
     value: false
+{% else %}
+    value: false
+{% endif %}
   - op: replace
     path: /metadata/labels/sas.com~1deployment
     value: 'user-specified'
@@ -32,10 +40,18 @@ patch: |-
     # This is the cron schedule by which the sas-start-all job is run
     # Example:
     #   value: '0 7 * * 1-5'
+{% if V4_CFG_VIYA_START_SCHEDULE is not none %}
     value: {{ V4_CFG_VIYA_START_SCHEDULE }}
+{% else %}
+    value: '0 7 * * 1-5'
+{% endif %}
   - op: replace
     path: /spec/suspend
+{% if V4_CFG_VIYA_START_SCHEDULE is not none %}
     value: false
+{% else %}
+    value: true
+{% endif %}
   - op: replace
     path: /metadata/labels/sas.com~1deployment
     value: 'user-specified'


### PR DESCRIPTION
### Changes
Allow the user to specify `V4_CFG_VIYA_START_SCHEDULE` or `V4_CFG_VIYA_STOP_SCHEDULE` rather than requiring both when using the start-stop transformer.
For the variable that the user chooses not to define, the transformer will be updated so the cronjob is set to be suspended. This allows the user to manually trigger the job when needed.

Behavior for other scenarios:
- If both are undefined the transformer is not included at all
- If both are defined they will have the cronjob expressions set as the value and .spec.suspend is false.

### Tests
Tested out the new scenario by setting `V4_CFG_VIYA_STOP_SCHEDULE` but not `V4_CFG_VIYA_START_SCHEDULE`. The stop job automatically triggered at the scheduled time and the start did not. I was able to manually trigger the start job.