### PR TITLE
feat: (IAC-667) add the ability to install the aws ebs csi driver in DAC

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -315,7 +315,6 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| EBS_CSI_DRIVER_ENABLED | Whether to deploy the aws ebs csi driver into the cluster using helm | bool | true | false | | baseline |
 | EBS_CSI_DRIVER_CHART_URL | aws ebs csi driver helm chart url | string | https://kubernetes-sigs.github.io/aws-ebs-csi-driver | false | | baseline |
 | EBS_CSI_DRIVER_CHART_NAME| aws ebs csi driver helm chart name | string | aws-ebs-csi-driver | false | | baseline |
 | EBS_CSI_DRIVER_CHART_VERSION | aws ebs csi driver helm chart version | string | 2.11.1 | false | | baseline |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -309,6 +309,20 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | CLUSTER_AUTOSCALER_ACCOUNT | cluster autoscaler aws role arn | string | | false | Required to enable cluster-autoscaler on AWS | baseline |
 | CLUSTER_AUTOSCALER_LOCATION | aws region where kubernetes cluster resides | string | us-east-1 | false | | baseline |
 
+### EBS CSI Driver
+
+The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS clusters. 
+
+| Name | Description | Type | Default | Required | Notes | Tasks |
+| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+| EBS_CSI_DRIVER_ENABLED | Whether to deploy the aws ebs csi driver into the cluster using helm | bool | true | false | | baseline |
+| EBS_CSI_DRIVER_CHART_URL | aws ebs csi driver helm chart url | string | https://kubernetes-sigs.github.io/aws-ebs-csi-driver | false | | baseline |
+| EBS_CSI_DRIVER_CHART_NAME| aws ebs csi driver helm chart name | string | aws-ebs-csi-driver | false | | baseline |
+| EBS_CSI_DRIVER_CHART_VERSION | aws ebs csi driver helm chart version | string | 2.11.1 | false | | baseline |
+| EBS_CSI_DRIVER_CONFIG | aws ebs csi driver helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
+| EBS_CSI_DRIVER_ACCOUNT | cluster autoscaler aws role arn | string | | false | Required to enable the aws ebs csi driver on AWS | baseline |
+| EBS_CSI_DRIVER_LOCATION | aws region where kubernetes cluster resides | string | us-east-1 | false | | baseline |
+
 ### Ingress-nginx
 
 | Name | Description | Type | Default | Required | Notes | Tasks |

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -121,6 +121,23 @@ CLUSTER_AUTOSCALER_CONFIG:
       annotations:
         "eks.amazonaws.com/role-arn": "{{ CLUSTER_AUTOSCALER_ACCOUNT }}"
 
+## EBS CSI Driver
+EBS_CSI_DRIVER_ENABLED: true
+EBS_CSI_DRIVER_NAME: aws-ebs-csi-driver
+EBS_CSI_DRIVER_NAMESPACE: kube-system
+EBS_CSI_DRIVER_CHART_NAME: aws-ebs-csi-driver
+EBS_CSI_DRIVER_CHART_URL: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+EBS_CSI_DRIVER_CHART_VERSION: 2.11.1
+EBS_CSI_DRIVER_ACCOUNT: null
+EBS_CSI_DRIVER_LOCATION: us-east-1
+EBS_CSI_DRIVER_CONFIG:
+  controller:
+    region: "{{ EBS_CSI_DRIVER_LOCATION }}"
+    serviceAccount:
+      create: true
+      name: ebs-csi-controller-sa
+      annotations:
+        "eks.amazonaws.com/role-arn": "{{ EBS_CSI_DRIVER_ACCOUNT }}"
 
 
 private_ingress:

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -45,6 +45,17 @@
   tags:
     - baseline
 
+- name: Include ebs-csi-driver
+  include_tasks: 
+    file: ebs-csi-driver.yaml
+  when:
+    - PROVIDER == "aws"
+    - K8S_SERVER_VERSION|float >= 1.23
+    - EBS_CSI_DRIVER_ACCOUNT is defined
+    - EBS_CSI_DRIVER_ACCOUNT is not none
+  tags:
+    - baseline
+
 - name: Include cert manager
   include_tasks: 
     file: cert-manager.yaml

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -50,7 +50,7 @@
     file: ebs-csi-driver.yaml
   when:
     - PROVIDER == "aws"
-    - K8S_SERVER_VERSION|float >= 1.23
+    - K8S_VERSION|float >= 1.23
     - EBS_CSI_DRIVER_ACCOUNT is defined
     - EBS_CSI_DRIVER_ACCOUNT is not none
   tags:

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -88,6 +88,24 @@
       when:
         - tfstate.postgres_servers is defined
         - tfstate.postgres_servers.value|length > 0
+    - name: tfstate - ebs csi driver account
+      set_fact: 
+        EBS_CSI_DRIVER_ACCOUNT: "{{ tfstate.ebs_csi_account.value }}"
+      when:
+        - tfstate.ebs_csi_account is defined
+        - tfstate.ebs_csi_account.value|length > 0
+    - name: tfstate - ebs csi driver location
+      set_fact: 
+        EBS_CSI_DRIVER_LOCATION: "{{ tfstate.location.value }}"
+      when:
+        - tfstate.location is defined
+        - tfstate.location.value|length > 0
+    - name: tfstate - k8s server version
+      set_fact: 
+        K8S_SERVER_VERSION: "{{ tfstate.k8s_server_version.value }}"
+      when:
+        - tfstate.k8s_server_version is defined
+        - tfstate.k8s_server_version.value|length > 0
     - name: tfstate - cluster autoscaler account
       set_fact: 
         CLUSTER_AUTOSCALER_ACCOUNT: "{{ tfstate.autoscaler_account.value }}"

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -100,12 +100,12 @@
       when:
         - tfstate.location is defined
         - tfstate.location.value|length > 0
-    - name: tfstate - k8s server version
+    - name: tfstate - kubernetes version
       set_fact: 
-        K8S_SERVER_VERSION: "{{ tfstate.k8s_server_version.value }}"
+        K8S_VERSION: "{{ tfstate.k8s_version.value }}"
       when:
-        - tfstate.k8s_server_version is defined
-        - tfstate.k8s_server_version.value|length > 0
+        - tfstate.k8s_version is defined
+        - tfstate.k8s_version.value|length > 0
     - name: tfstate - cluster autoscaler account
       set_fact: 
         CLUSTER_AUTOSCALER_ACCOUNT: "{{ tfstate.autoscaler_account.value }}"


### PR DESCRIPTION
Adding support for DAC to install the aws ebs csi driver.
AWS EKS v1.23 and later requires the installation and configuration of the aws elastic block storage csi driver to enable the dynamic provisioning of physical volumes for applications that are configured to use the default storage class.