### PR TITLE
feat: (IAC-707) Remove CERT_MANAGER_ENABLED and use V4_CFG_TLS_GENERATOR

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -185,7 +185,7 @@ Viya 4 supports 2 different types of certificate generators, cert-manager and op
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. | viya, cluster-logging, cluster-monitoring |
+| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. If set to `cert-manager`, `cert-manager` will be installed during the baselining. | viya, cluster-logging, cluster-monitoring |
 | V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |
@@ -288,12 +288,14 @@ Notes:
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| CERT_MANAGER_ENABLED | Whether to deploy cert-manager into the cluster using helm | bool | false | false | Required if V4_CFG_TLS_GENERATOR is set to `cert-manager` and it's not already installed | baseline |
 | CERT_MANAGER_NAMESPACE | cert-manager helm install namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager helm chart url | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager helm chart name | string | cert-manager| false | | baseline |
 | CERT_MANAGER_CHART_VERSION | cert-manager helm chart version | string | 1.9.1 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
+
+Notes:
+  - cert-manager will only be installed if `V4_CFG_TLS_GENERATOR` is set to "cert-manager"
 
 ### Cluster Autoscaler
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -185,7 +185,7 @@ Viya 4 supports 2 different types of certificate generators, cert-manager and op
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. If set to `cert-manager`, `cert-manager` will be installed during the baselining. | viya, cluster-logging, cluster-monitoring |
+| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. If set to `cert-manager`, `cert-manager` will be installed during baselining. | viya, cluster-logging, cluster-monitoring |
 | V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -185,7 +185,7 @@ Viya 4 supports 2 different types of certificate generators, cert-manager and op
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. If set to `cert-manager`, `cert-manager` will be installed during baselining. | viya, cluster-logging, cluster-monitoring |
+| V4_CFG_TLS_GENERATOR | Which tool to use for certificate generation | string | openssl | false | Supported values: [`cert-manager`,`openssl`]. If set to `cert-manager`, `cert-manager` will be installed during baselining. | baseline, viya, cluster-logging, cluster-monitoring |
 | V4_CFG_TLS_MODE | Which TLS mode to configure | string | front-door | false | Supported values: [`full-stack`,`front-door`,`disabled.`] When deploying full-stack you must set V4_CFG_TLS_TRUSTED_CA_CERTS to trust external postgres server ca. | all |
 | V4_CFG_TLS_CERT | Path to ingress certificate file | string | | false | If specified, used instead of cert-manager issued certificates | viya |
 | V4_CFG_TLS_KEY | Path to ingress key file | string | | false | Required when V4_CFG_TLS_CERT is specified | viya |

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -4,7 +4,6 @@ V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_MODE: public
 
 ## Cert-manager
-CERT_MANAGER_ENABLED: false
 CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager

--- a/roles/baseline/tasks/cert-manager.yaml
+++ b/roles/baseline/tasks/cert-manager.yaml
@@ -11,7 +11,8 @@
     create_namespace: true
     wait: true
   when:
-    - (V4_CFG_TLS_GENERATOR | default('default_value', 'openssl')) == 'cert-manager'
+    - V4_CFG_TLS_GENERATOR is defined
+    - V4_CFG_TLS_GENERATOR == 'cert-manager'
   tags:
     - install
     - update

--- a/roles/baseline/tasks/cert-manager.yaml
+++ b/roles/baseline/tasks/cert-manager.yaml
@@ -11,7 +11,7 @@
     create_namespace: true
     wait: true
   when:
-    - CERT_MANAGER_ENABLED
+    - (V4_CFG_TLS_GENERATOR | default('default_value', 'openssl')) == 'cert-manager'
   tags:
     - install
     - update


### PR DESCRIPTION
## Changes
Before if a user wanted to use cert-manager in their cluster they need to set two flags: `V4_CFG_TLS_GENERATOR:cert-manager` & `CERT_MANAGER_ENABLED:true`
`V4_CFG_TLS_GENERATOR` controlling the TLS generator that Viya will use, and `CERT_MANAGER_ENABLED` controlling whether or not cert-manager should be installed by the DaC codebase. Even though it is documented to use both, often times user's only set one of these two flags resulting in issues.

This change makes is so that if the user sets `V4_CFG_TLS_GENERATOR:cert-manager`, it will now install cert-manager during the baseline stage, so we no longer need to manage two variables for cert-manager. `CERT_MANAGER_ENABLED` is now removed since setting `V4_CFG_TLS_GENERATOR:cert-manager` provides the same functionality.

## Tests
More details in internal ticket

- Performed a deployment with  `V4_CFG_TLS_GENERATOR:cert-manager` and verified that cert-manager was installed during the baseline phase
- Performed a deployment with `V4_CFG_TLS_GENERATOR:openssl` and verified that cert-manager was not installed during the baseline phase.