### PR TITLE
feat: (IAC-644) Add DaC support for crunchy v5 

### DIFF
--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -82,6 +82,17 @@
     - install
     - update
 
+- name: deploy - Uninstall postgresclusters
+  environment:
+    KUBECONFIG: "{{ KUBECONFIG }}"
+  ansible.builtin.shell: >
+    kubectl -n {{ NAMESPACE }} delete postgresclusters --selector="sas.com/deployment=sas-viya" --ignore-not-found=true
+  ignore_errors: yes
+  when:
+    - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  tags:
+    - uninstall
+
 - name: Remove Viya
   community.kubernetes.k8s:
     state: absent

--- a/roles/vdm/tasks/mirror.yaml
+++ b/roles/vdm/tasks/mirror.yaml
@@ -24,7 +24,7 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { transformers: "mirror.yaml", vdm: true, priority: 65, max: "2022.09" }
+      - { transformers: "mirror.yaml", vdm: true, priority: 65 }
       - { generators: "mirror.yaml", vdm: true, max: "2022.09" }
       - { generators: "mirror.v2.yaml", vdm: true, min: "2022.10" }
   tags: 

--- a/roles/vdm/tasks/mirror.yaml
+++ b/roles/vdm/tasks/mirror.yaml
@@ -19,14 +19,14 @@
     - update
 
 - name: mirror - overlay
-    overlay_facts:
-      cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
-      cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
-      existing: "{{ vdm_overlays }}"
-      add:
-        - { transformers: "mirror.yaml", vdm: true, priority: 65, max: "2022.09" }
-        - { generators: "mirror.yaml", vdm: true, max: "2022.09" }
-        - { generators: "mirror.v2.yaml", vdm: true, min: "2022.10" }
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: "mirror.yaml", vdm: true, priority: 65, max: "2022.09" }
+      - { generators: "mirror.yaml", vdm: true, max: "2022.09" }
+      - { generators: "mirror.v2.yaml", vdm: true, min: "2022.10" }
   tags: 
     - install
     - uninstall

--- a/roles/vdm/tasks/mirror.yaml
+++ b/roles/vdm/tasks/mirror.yaml
@@ -19,30 +19,14 @@
     - update
 
 - name: mirror - overlay
-  block:
-    - name: v4 crunchy
-      overlay_facts:
-        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
-        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
-        existing: "{{ vdm_overlays }}"
-        add:
-          - { transformers: "mirror.yaml", vdm: true, priority: 65 }
-          - { generators: "mirror.yaml", vdm: true }
-      when:
-        - V4_CFG_CADENCE_VERSION is version('2022.10', "<")
-        - not V4_CFG_CADENCE_NAME|lower == "fast"
-    - name: v5 crunchy
-      overlay_facts:
-        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
-        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
-        existing: "{{ vdm_overlays }}"
-        add:
-          - { transformers: "mirror.yaml", vdm: true, priority: 65 }
-          - { generators: "mirror_v2.yaml", vdm: true }
-      when:
-        - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
-  when:
-    - true 
+    overlay_facts:
+      cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+      cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+      existing: "{{ vdm_overlays }}"
+      add:
+        - { transformers: "mirror.yaml", vdm: true, priority: 65, max: "2022.09" }
+        - { generators: "mirror.yaml", vdm: true, max: "2022.09" }
+        - { generators: "mirror.v2.yaml", vdm: true, min: "2022.10" }
   tags: 
     - install
     - uninstall

--- a/roles/vdm/tasks/mirror.yaml
+++ b/roles/vdm/tasks/mirror.yaml
@@ -19,13 +19,30 @@
     - update
 
 - name: mirror - overlay
-  overlay_facts:
-    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
-    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
-    existing: "{{ vdm_overlays }}"
-    add:
-      - { transformers: "mirror.yaml", vdm: true, priority: 65 }
-      - { generators: "mirror.yaml", vdm: true }
+  block:
+    - name: v4 crunchy
+      overlay_facts:
+        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+        existing: "{{ vdm_overlays }}"
+        add:
+          - { transformers: "mirror.yaml", vdm: true, priority: 65 }
+          - { generators: "mirror.yaml", vdm: true }
+      when:
+        - V4_CFG_CADENCE_VERSION is version('2022.10', "<")
+        - not V4_CFG_CADENCE_NAME|lower == "fast"
+    - name: v5 crunchy
+      overlay_facts:
+        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+        existing: "{{ vdm_overlays }}"
+        add:
+          - { transformers: "mirror.yaml", vdm: true, priority: 65 }
+          - { generators: "mirror_v2.yaml", vdm: true }
+      when:
+        - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  when:
+    - true 
   tags: 
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/gcp-cloud-sql-proxy.yaml
+++ b/roles/vdm/tasks/postgres/gcp-cloud-sql-proxy.yaml
@@ -33,7 +33,8 @@
         existing: "{{ vdm_overlays }}"
         add:
           - { resources: "cloud-sql-proxy-{{ role }}-instance.yaml", vdm: true }
-          - { transformers: "overlays/external-postgres/googlecloud-full-stack-tls-transformer.yaml", priority: 55 }
+          - { transformers: "overlays/external-postgres/googlecloud-full-stack-tls-transformer.yaml", priority: 55, max: "2022.09" }
+          - { transformers: "overlays/postgres/external-postgres/gcp-tls-transformer.yaml", priority: 55, min: "2022.10" }
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -41,10 +41,10 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { resources: "overlays/crunchydata/postgres-operator" }
-      - { resources: "overlays/postgres/platform-postgres" }
-      - { components: "components/crunchydata/internal-platform-postgres" }
-  when:
+      - { resources: "overlays/crunchydata/postgres-operator", min: "2022.10" }
+      - { resources: "overlays/postgres/platform-postgres", min: "2022.10" }
+      - { components: "components/crunchydata/internal-platform-postgres", min: "2022.10" }
+  when: 
     - settings.internal
     - role == "default"
     - crunchydata_folder.stat.exists
@@ -59,7 +59,7 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { resources: "overlays/internal-postgres" }
+      - { resources: "overlays/internal-postgres", max: "2022.09" }
   when: 
     - settings.internal
     - role == "default"
@@ -85,7 +85,7 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { resources: "overlays/internal-postgres/{{ role }}" }
+      - { resources: "overlays/internal-postgres/{{ role }}", max: "2022.09" }
   when: 
     - settings.internal
     - result.stat.exists

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -44,7 +44,7 @@
       - { resources: "overlays/crunchydata/postgres-operator" }
       - { resources: "overlays/postgres/platform-postgres" }
       - { components: "components/crunchydata/internal-platform-postgres" }
-  when: 
+  when:
     - settings.internal
     - role == "default"
     - crunchydata_folder.stat.exists
@@ -94,6 +94,41 @@
     - uninstall
     - update
 
+- name: postgres instance - external post 2022.10
+  block:
+  - name: postgres instance - external copy postgres-user.env
+    template:
+      src: "postgres-user.env"
+      dest: "{{ DEPLOY_DIR }}/site-config/postgres-{{ role }}-user.env"
+      mode: "0660"
+  - name: postgres instance - external copy secret generator template
+    template:
+      src: "{{ role_path }}/templates/generators/postgres-secrets.yaml"
+      dest: "{{ role_path }}/templates/generators/postgres-{{ role }}-secrets.yaml"
+      mode: "0660"
+  - name: postgres instance - external copy dataserver transformer template
+    template:
+      src: "{{ role_path }}/templates/transformers/dataserver-transformer.yaml"
+      dest: "{{ role_path }}/templates/transformers/{{ role }}-dataserver-transformer.yaml"
+      mode: "0660"
+  - name: postgres instance - external kustomization entries
+    overlay_facts:
+      cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+      cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+      existing: "{{ vdm_overlays }}"
+      add:
+        - { transformers: "{{ role }}-dataserver-transformer.yaml", min: "2022.10", vdm: true}
+        - { generators: "postgres-{{ role }}-secrets.yaml", min: "2022.10", vdm: true}
+  when:
+    - not settings.internal
+    - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  tags:
+    - install
+    - uninstall
+    - update
+
+# TODO Fix Logic for tasks below
+
 - block:
   - name: postgres instance - crd
     template:
@@ -107,8 +142,29 @@
       add:
         - { resources: "postgres-{{ role }}-instance.yaml", vdm: true }
   when:
-    - not settings.internal or ( settings.internal and role != "default" and not result.stat.exists )
+    - settings.internal and role != "default" and not result.stat.exists
     - not crunchydata_folder.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
+- block:
+  - name: postgres instance - external crd
+    template:
+      src: "{{ role_path }}/templates/resources/postgres-instance.yaml"
+      dest: "{{ role_path }}/templates/resources/postgres-{{ role }}-instance.yaml"
+      mode: "0660"
+  - overlay_facts:
+      cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+      cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+      existing: "{{ vdm_overlays }}"
+      add:
+        - { resources: "postgres-{{ role }}-instance.yaml", vdm: true }
+  when:
+    - not settings.internal
+    - V4_CFG_CADENCE_VERSION is version('2022.10', "<")
+    - V4_CFG_CADENCE_NAME|lower != "fast"
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -8,6 +8,51 @@
     - uninstall
     - update
 
+- name: postgres - crunchydata folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/crunchydata"
+  register: crunchydata_folder
+  when: settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- set_fact:
+    internal_crunchy: crunchydata_folder.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres - internal-postgres folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/internal-postgres"
+  register: internal_pg_folder
+  when: settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres - internal crunchydata default
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { resources: "overlays/crunchydata/postgres-operator" }
+      - { resources: "overlays/postgres/platform-postgres" }
+      - { components: "components/crunchydata/internal-platform-postgres" }
+  when: 
+    - settings.internal
+    - role == "default"
+    - crunchydata_folder.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: postgres - internal default
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
@@ -18,6 +63,7 @@
   when: 
     - settings.internal
     - role == "default"
+    - internal_pg_folder.stat.exists
   tags:
     - install
     - uninstall
@@ -62,6 +108,7 @@
         - { resources: "postgres-{{ role }}-instance.yaml", vdm: true }
   when:
     - not settings.internal or ( settings.internal and role != "default" and not result.stat.exists )
+    - not crunchydata_folder.stat.exists
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -76,6 +76,7 @@
     - uninstall
     - update
 
+# Updates to support Crunchy v5 internal PostgreSQL
 - name: postgres crunchy v5 - copy custom config 
   copy:
     src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-transformer.yaml"
@@ -99,8 +100,6 @@
   when: 
     - crunchydata_folder.stat.exists
     - settings.internal
-  loop_control:
-    loop_var: outer_item
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -5,13 +5,21 @@
     - uninstall
     - update
 
-- set_fact:
-    CUSTOM_CONFIGURATION: |-
-      postgresql:
-        parameters:
-          max_connections: {{ MAX_CONNECTIONS }}
-          max_prepared_transactions: {{ MAX_CONNECTIONS }}
-  when: crunchydata_folder.stat.exists
+- name: postgres crunchy v5 - crunchydata tuning folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning"
+  register: crunchy_tuning_folder
+  when: settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres - internal-postgres custom-config folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/examples/postgres/custom-config"
+  register: custom_config_folder
+  when: settings.internal
   tags:
     - install
     - uninstall
@@ -28,7 +36,7 @@
   loop_control:
     loop_var: file
   when: 
-    - internal_pg_folder.stat.exists
+    - custom_config_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -54,7 +62,7 @@
       loop_control:
         loop_var: outer_item
   when: 
-    - internal_pg_folder.stat.exists
+    - custom_config_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -69,7 +77,7 @@
       - { transformers: "sas-{{ 'postgres' if role == 'default' else role }}-custom-config-transformer.yaml", vdm: true, priority: 65 }
       - { resources: "sas-{{ 'postgres' if role == 'default' else role }}-custom-config.yaml", vdm: true,}
   when: 
-    - internal_pg_folder.stat.exists
+    - custom_config_folder.stat.exists
     - settings.internal
   tags: 
     - install
@@ -77,6 +85,18 @@
     - update
 
 # Updates to support Crunchy v5 internal PostgreSQL
+- set_fact:
+    CUSTOM_CONFIGURATION: |-
+      postgresql:
+        parameters:
+          max_connections: {{ MAX_CONNECTIONS }}
+          max_prepared_transactions: {{ MAX_CONNECTIONS }}
+  when: crunchy_tuning_folder.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: postgres crunchy v5 - copy custom config 
   copy:
     src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-transformer.yaml"
@@ -85,7 +105,7 @@
   loop_control:
     loop_var: file
   when: 
-    - crunchydata_folder.stat.exists
+    - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -98,7 +118,7 @@
     regexp: '#.*$'
     state: absent
   when: 
-    - crunchydata_folder.stat.exists
+    - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -114,7 +134,7 @@
     - { regexp: "{% raw %}{{ CONFIGURATION }}{% endraw %}", replace: "{{ CUSTOM_CONFIGURATION | indent( width=6, first=False) }}" }
     - { regexp: "{% raw %}{{ POSTGRESCLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform' if role == 'default' else role }}-postgres" }
   when: 
-    - crunchydata_folder.stat.exists
+    - crunchy_tuning_folder.stat.exists
     - settings.internal
   loop_control:
     loop_var: outer_item
@@ -131,7 +151,7 @@
     add:
       - { transformers: "{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
   when: 
-    - crunchydata_folder.stat.exists
+    - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags: 
     - install

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -1,5 +1,17 @@
 - set_fact:
-    max_connections: '{{ ((((V4MT_TENANT_IDS.split(",") | length) | int ) + 1 ) * 1128) }}'
+    MAX_CONNECTIONS: '{{ ((((V4MT_TENANT_IDS.split(",") | length) | int ) + 1 ) * 1128) }}'
+  tags:
+    - install
+    - uninstall
+    - update
+
+- set_fact:
+    CUSTOM_CONFIGURATION: |-
+      postgresql:
+        parameters:
+          max_connections: {{ MAX_CONNECTIONS }}
+          max_prepared_transactions: {{ MAX_CONNECTIONS }}
+  when: crunchydata_folder.stat.exists
   tags:
     - install
     - uninstall
@@ -16,6 +28,7 @@
   loop_control:
     loop_var: file
   when: 
+    - internal_pg_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -36,11 +49,12 @@
         insertafter: "data:" 
         line: "{{ outer_item }}"
       with_items:
-        - '  max_prepared_transactions: "{{ max_connections }}"'
-        - '  max_connections: "{{ max_connections }}"'
+        - '  max_prepared_transactions: "{{ MAX_CONNECTIONS }}"'
+        - '  max_connections: "{{ MAX_CONNECTIONS }}"'
       loop_control:
         loop_var: outer_item
   when: 
+    - internal_pg_folder.stat.exists
     - settings.internal
   tags:
     - install
@@ -55,6 +69,70 @@
       - { transformers: "sas-{{ 'postgres' if role == 'default' else role }}-custom-config-transformer.yaml", vdm: true, priority: 65 }
       - { resources: "sas-{{ 'postgres' if role == 'default' else role }}-custom-config.yaml", vdm: true,}
   when: 
+    - internal_pg_folder.stat.exists
+    - settings.internal
+  tags: 
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - copy custom config 
+  copy:
+    src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-transformer.yaml"
+    dest: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    mode: "0660"
+  loop_control:
+    loop_var: file
+  when: 
+    - crunchydata_folder.stat.exists
+    - settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - remove commented block
+  lineinfile:
+    path: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    regexp: '#.*$'
+    state: absent
+  when: 
+    - crunchydata_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - update config
+  replace:
+    path: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    regexp: "{{ outer_item.regexp }}"
+    replace: "{{ outer_item.replace }}"
+  with_items:
+    - { regexp: "{% raw %}{{ CONFIGURATION }}{% endraw %}", replace: "{{ CUSTOM_CONFIGURATION | indent( width=6, first=False) }}" }
+    - { regexp: "{% raw %}{{ POSTGRESCLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform' if role == 'default' else role }}-postgres" }
+  when: 
+    - crunchydata_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - add custom config transformer to kustomization
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: "{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
+  when: 
+    - crunchydata_folder.stat.exists
     - settings.internal
   tags: 
     - install

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -75,7 +75,6 @@
         cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
         existing: "{{ vdm_overlays }}"
         add:
-          - { resources: "overlays/postgres/platform-postgres", min: "2022.10" }
           - { transformers: "overlays/external-postgres/external-postgres-transformer.yaml", max: "2022.09" }
       when:
         - not internal_postgres
@@ -111,7 +110,7 @@
         cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
         existing: "{{ vdm_overlays }}"
         add:
-          - { transformers: "overlays/external-postgres/external-postgres-transformer.yaml" }
+          - { resources: "overlays/postgres/platform-postgres", min: "2022.10" }
       when: 
         - not internal_postgres
     - name: postgres - instance

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -75,8 +75,9 @@
         cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
         existing: "{{ vdm_overlays }}"
         add:
-          - { transformers: "overlays/external-postgres/external-postgres-transformer.yaml" }
-      when: 
+          - { resources: "overlays/postgres/platform-postgres", min: "2022.10" }
+          - { transformers: "overlays/external-postgres/external-postgres-transformer.yaml", max: "2022.09" }
+      when:
         - not internal_postgres
     - name: postgres - instance
       include_tasks: postgres-instance.yaml

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -86,7 +86,42 @@
         internal: "{{ internal_postgres }}"
       with_dict: "{{ V4_CFG_POSTGRES_SERVERS }}"
   when:
-    - V4_CFG_CADENCE_VERSION is version('2021.1.4', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_CADENCE_VERSION is version('2021.1.4', ">=")
+    - V4_CFG_CADENCE_VERSION is version('2022.10', "<")
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres - post 2022.10
+  block:
+    - name: postgres - internal crunchy v5
+      overlay_facts:
+        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+        existing: "{{ vdm_overlays }}"
+        add:
+          - { resources: "overlays/crunchydata/postgres-operator" }
+      when: 
+        - internal_postgres
+    - name: postgres - external
+      overlay_facts:
+        cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+        cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+        existing: "{{ vdm_overlays }}"
+        add:
+          - { transformers: "overlays/external-postgres/external-postgres-transformer.yaml" }
+      when: 
+        - not internal_postgres
+    - name: postgres - instance
+      include_tasks: postgres-instance.yaml
+      vars:
+        role: "{{ item.key }}"
+        settings: "{{ item.value }}"
+        internal: "{{ internal_postgres }}"
+      with_dict: "{{ V4_CFG_POSTGRES_SERVERS }}"
+  when:
+    - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -101,7 +101,7 @@
         cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
         existing: "{{ vdm_overlays }}"
         add:
-          - { resources: "overlays/crunchydata/postgres-operator" }
+          - { resources: "overlays/crunchydata/postgres-operator", min: "2022.10" }
       when: 
         - internal_postgres
     - name: postgres - external

--- a/roles/vdm/templates/generators/mirror.v2.yaml
+++ b/roles/vdm/templates/generators/mirror.v2.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: builtin
+kind: ConfigMapGenerator
+metadata:
+  name: input
+behavior: merge
+literals:
+  - IMAGE_REGISTRY={{ V4_CFG_CR_HOST }}

--- a/roles/vdm/templates/generators/mirror_v2.yaml
+++ b/roles/vdm/templates/generators/mirror_v2.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: builtin
+kind: ConfigMapGenerator
+metadata:
+  name: input
+behavior: merge
+literals:
+  - IMAGE_REGISTRY={{ V4_CFG_CR_HOST }}

--- a/roles/vdm/templates/generators/mirror_v2.yaml
+++ b/roles/vdm/templates/generators/mirror_v2.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: builtin
-kind: ConfigMapGenerator
-metadata:
-  name: input
-behavior: merge
-literals:
-  - IMAGE_REGISTRY={{ V4_CFG_CR_HOST }}

--- a/roles/vdm/templates/generators/postgres-secrets.yaml
+++ b/roles/vdm/templates/generators/postgres-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: builtin
+kind: SecretGenerator
+type: Opaque
+behavior: add
+metadata:
+  name: {{ role }}-platform-postgres-user
+envs:
+  - site-config/postgres-{{ role }}-user.env

--- a/roles/vdm/templates/generators/sql-proxy-serviceaccountkey.yaml
+++ b/roles/vdm/templates/generators/sql-proxy-serviceaccountkey.yaml
@@ -1,0 +1,8 @@
+apiVersion: builtin
+kind: SecretGenerator
+type: Opaque
+behavior: add
+metadata:
+  name: {{ role }}-platform-postgres-user
+files:
+  - site-config/postgres-{{ role }}-user.env

--- a/roles/vdm/templates/postgres-user.env
+++ b/roles/vdm/templates/postgres-user.env
@@ -1,0 +1,2 @@
+username={{ settings.admin }}
+password={{ settings.password }}

--- a/roles/vdm/templates/transformers/dataserver-transformer.yaml
+++ b/roles/vdm/templates/transformers/dataserver-transformer.yaml
@@ -1,0 +1,34 @@
+{%- set db = db_default_name_map[role] if ('database' not in settings and role in db_default_name_map) else settings.database|default(role, true) -%}
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: sas-platform-postgres-dataserver-transformer
+patch: |-
+  - op: replace
+    path: /spec/databases/0/name
+    value: {{ db }}
+
+  - op: replace
+    path: /spec/users/0/credentials/input
+    value:
+      secretRef:
+        name: {{ role }}-platform-postgres-user
+      usernameKey: username # For internal use, do not modify
+      passwordKey: password # For internal use, do not modify
+
+  - op: replace
+    path: /spec/registrations/0/host
+    value: {{ settings.fqdn }}
+
+  - op: replace
+    path: /spec/registrations/0/port
+    value: {{ settings.server_port|default(5432, true) }}
+
+  - op: replace
+    path: /spec/ssl
+    value: true
+target:
+  group: webinfdsvr.sas.com
+  kind: DataServer
+  version: v1beta1
+  name: sas-platform-postgres


### PR DESCRIPTION
# Changes:
- DaC changes related to supporting internal v5 crunchy postgres db.
- Crunchy v5 support for CDS Postgres is still to be added.
- (IAC-724) Update max_connections for Crunchy v5 internal postgres to support Multi-tenancy
- DaC changes related to supporting external crunchy postgres DBs

# Tests:
See internal tickets for details