### PR TITLE
feat: (IAC-723) Uninstall baseline components last during uninstall phase

### DIFF
--- a/playbooks/playbook.yaml
+++ b/playbooks/playbook.yaml
@@ -33,9 +33,10 @@
         - V4_CFG_MANAGE_STORAGE
       tags:
         - viya
-    - name: baseline role
+    - name: baseline role install
       include_role:
         name: baseline
+      when: ('baseline' in ansible_run_tags) and ('install' in ansible_run_tags)
       tags:
         - baseline
     - name: monitoring role - cluster
@@ -61,6 +62,12 @@
         tasks_from: viya-monitoring
       tags:
         - viya-monitoring
+    - name: baseline role uninstall
+      include_role:
+        name: baseline
+      when: ('baseline' in ansible_run_tags) and ('uninstall' in ansible_run_tags)
+      tags:
+        - baseline
     - name: Delete tmpdir
       file:
         path: "{{ tmpdir.path }}"


### PR DESCRIPTION
For AWS EKS 1.23 or later clusters, cluster-logging, cluster-monitoring, viya and other application components rely upon the ebs csi driver for the dynamic creation of physical volumes.
Those components depend on the ebs csi driver to be resident in the cluster until it is no longer needed.
Prior to this change, all baseline components, including the ebs csi driver would be uninstalled first during the DAC uninstall phase when the baseline component and any other application components were being uninstalled.
After this change, when the baseline and application tags are specified together for uninstall, all application components will be uninstalled prior to the baseline components being uninstalled. Moving the order so baseline components uninstall last will allow the ebs csi driver to be running in the cluster to manage physical volume destruction while each application component uninstalls.