### PR TITLE
feat: (IAC-739) Support a CDSPostgreSQL instance for Crunchy v5

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -211,6 +211,18 @@ V4_CFG_POSTGRES_SERVERS:
     ...
   ...
 ```
+Several SAS Viya offerings require a second internal Postgres instance referred to as SAS Common Data Store or CDS PostgreSQL. See details [here](https://pubshelpcenter.unx.sas.com/test/doc/en/itopscdc/v_033/dplyml0phy0dkr/n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). To deploy and configure a CDS PostgreSQL instance in addition to the default internal platform Postgres instance, specify "cds-postgres" for your second Postgres instance as shown in the example below:
+
+```bash
+V4_CFG_POSTGRES_SERVERS:
+  default:
+    internal: true
+    ...
+  cds-postgres:
+    internal: true
+    ...
+  ...
+```
 
 **NOTE**: the `default` elements is always required . This will be the default server. Below is the list of parameters each element can contain.
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -211,7 +211,7 @@ V4_CFG_POSTGRES_SERVERS:
     ...
   ...
 ```
-Several SAS Viya offerings require a second internal Postgres instance referred to as SAS Common Data Store or CDS PostgreSQL. See details [here](https://pubshelpcenter.unx.sas.com/test/doc/en/itopscdc/v_033/dplyml0phy0dkr/n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). To deploy and configure a CDS PostgreSQL instance in addition to the default internal platform Postgres instance, specify "cds-postgres" for your second Postgres instance as shown in the example below:
+Several SAS Viya offerings require a second internal Postgres instance referred to as SAS Common Data Store or CDS PostgreSQL. See details [here](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). To deploy and configure a CDS PostgreSQL instance in addition to the default internal platform Postgres instance, specify "cds-postgres" for your second Postgres instance as shown in the example below:
 
 ```bash
 V4_CFG_POSTGRES_SERVERS:

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -211,7 +211,7 @@ V4_CFG_POSTGRES_SERVERS:
     ...
   ...
 ```
-Several SAS Viya offerings require a second internal Postgres instance referred to as SAS Common Data Store or CDS PostgreSQL. See details [here](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). To deploy and configure a CDS PostgreSQL instance in addition to the default internal platform Postgres instance, specify "cds-postgres" for your second Postgres instance as shown in the example below:
+Several SAS Viya offerings require a second internal Postgres instance referred to as SAS Common Data Store or CDS PostgreSQL. See details [here](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). The list of software offerings that include CDS PostgreSQL is located at [SAS Common Data Store Requirements (for SAS Planning and Retail Offerings)](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm#n03wzanutmc6gon1val5fykas9aa) in System Requirements for SAS Viya. To deploy and configure a CDS PostgreSQL instance in addition to the default internal platform Postgres instance, specify "cds-postgres" for your second Postgres instance as shown in the example below:
 
 ```bash
 V4_CFG_POSTGRES_SERVERS:

--- a/roles/vdm/tasks/cds.yaml
+++ b/roles/vdm/tasks/cds.yaml
@@ -1,5 +1,5 @@
 ---
-- name: planning - folder check
+- name: cds - folder check 
   stat:
     path: "{{ DEPLOY_DIR }}/sas-bases/overlays/sas-planning"
   register: result
@@ -8,7 +8,7 @@
     - uninstall
     - update
 
-- name: planning - add overlays
+- name: cds - add overlays
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -161,8 +161,8 @@
     - uninstall
     - update
 
-- name: Include Planning
-  include_tasks: planning.yaml
+- name: Include CDS
+  include_tasks: cds.yaml
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -161,6 +161,13 @@
     - uninstall
     - update
 
+- name: Include Planning
+  include_tasks: planning.yaml
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: Include Storage
   include_tasks: storage.yaml
   tags:

--- a/roles/vdm/tasks/planning.yaml
+++ b/roles/vdm/tasks/planning.yaml
@@ -1,0 +1,24 @@
+---
+- name: planning - folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/sas-planning"
+  register: result
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: planning - add overlays
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { resources: "overlays/sas-planning", min: "2022.10" }
+      - { transformers: "overlays/sas-planning/sas-planning-transformer.yaml", min: "2022.10" }
+  when:
+    - result.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -94,6 +94,32 @@
     - uninstall
     - update
 
+- name: postgres - cds v5 crunchy folder check
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/postgres/{{ role }}"
+  register: result
+  when: settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres - internal cds v5 crunchy
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { resources: "overlays/postgres/{{ role }}", min: "2022.10" }
+      - { components: "components/crunchydata/internal-{{ role }}", min: "2022.10" }
+  when: 
+    - settings.internal
+    - result.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: postgres instance - external post 2022.10
   block:
   - name: postgres instance - external copy postgres-user.env

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -5,6 +5,29 @@
     - uninstall
     - update
 
+- name: both internal
+  block:
+    - set_fact:
+        default_postgres_internal: "{{ V4_CFG_POSTGRES_SERVERS.default.internal }}"
+        cds_postgres_internal: "{{ V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal }}"
+      when:
+        - V4_CFG_POSTGRES_SERVERS.default is defined
+        - V4_CFG_POSTGRES_SERVERS['cds-postgres'] is defined
+        - V4_CFG_POSTGRES_SERVERS.default.internal is defined
+        - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal is defined
+    - fail:
+        msg: "When using CDS postgres, the default and CDS postgres instances must be internal servers"
+      when:
+        - default_postgres_internal is defined
+        - cds_postgres_internal is defined
+        - default_postgres_internal == false or cds_postgres_internal == false
+  when:
+    - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: postgres - gcp cloud-sql-proxy
   include_tasks: gcp-cloud-sql-proxy.yaml
   vars:

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -5,24 +5,14 @@
     - uninstall
     - update
 
-- name: both internal
-  block:
-    - set_fact:
-        default_postgres_internal: "{{ V4_CFG_POSTGRES_SERVERS.default.internal }}"
-        cds_postgres_internal: "{{ V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal }}"
-      when:
-        - V4_CFG_POSTGRES_SERVERS.default is defined
-        - V4_CFG_POSTGRES_SERVERS['cds-postgres'] is defined
-        - V4_CFG_POSTGRES_SERVERS.default.internal is defined
-        - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal is defined
-    - fail:
-        msg: "When using CDS postgres, the default and CDS postgres instances must be internal servers"
-      when:
-        - default_postgres_internal is defined
-        - cds_postgres_internal is defined
-        - default_postgres_internal == false or cds_postgres_internal == false
+- name: check cds-postgres is internal
+  ansible.builtin.fail:
+    msg: "CDS postgres instance must be internal server. To use CDS postgres, please reconfigure your infrastructure to set all your postgres servers internal"
   when:
     - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_POSTGRES_SERVERS['cds-postgres'] is defined
+    - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal is defined
+    - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal == false
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -5,7 +5,7 @@
     - uninstall
     - update
 
-- name: check cds-postgres is internal
+- name: fail - if cds-postgres is external
   ansible.builtin.fail:
     msg: "CDS postgres instance must be internal server. To use CDS postgres, please reconfigure your infrastructure to set all your postgres servers internal"
   when:


### PR DESCRIPTION
### Changes
Viya Retail and Planning application require the installation of a secondary PostgreSQL instance referred to as the Common Data Store Postgres instance.
This updates includes the support to install a secondary internal instance of Postgres named "cds-postgres" and can be triggered by including the following postgres clause in the ansible-vars.yaml file used to deploy Viya.

```yaml
## Postgres
V4_CFG_POSTGRES_SERVERS:
  default:
    internal: true
  cds-postgres:
    internal: true
```
### Tests
Testing included deploying a fast 2020 Inventory Fulfillment Viya order while specifying two Postgres instances as above. The presence of planning application schemas created in the CDS Postgres instance were used to verify the successful deployment and configuration of the CDS Postgres instance.