### PR TITLE
fix: (IAC-742) Lookup cluster K8S version information from within DAC

### DIFF
--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -47,7 +47,7 @@
 
 - name: Lookup K8s version info
   block:
-    - name: Retreive K8s cluster information
+    - name: Retrieve K8s cluster information
       community.kubernetes.k8s_cluster_info:
         kubeconfig: "{{ KUBECONFIG }}"
       register: cluster_info

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -53,10 +53,7 @@
       register: cluster_info
     - name: Set the K8s server version
       set_fact:
-        K8S_VERSION: "{{ cluster_info.version.server.kubernetes.major + '.' + cluster_info.version.server.kubernetes.minor }}"
-    - name: Output K8S_VERSION
-      debug:
-        msg: "{{ K8S_VERSION }}"
+        K8S_VERSION: "{{ cluster_info.version.server.kubernetes.major + '.' + cluster_info.version.server.kubernetes.minor | regex_replace('\\+$', '') }}"
   tags:
     - baseline
 

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -45,7 +45,7 @@
   tags:
     - baseline
 
-- name: Query K8s cluster info
+- name: Lookup K8s version info
   block:
     - name: Retreive K8s cluster information
       community.kubernetes.k8s_cluster_info:

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -45,6 +45,21 @@
   tags:
     - baseline
 
+- name: Query K8s cluster info
+  block:
+    - name: Retreive K8s cluster information
+      community.kubernetes.k8s_cluster_info:
+        kubeconfig: "{{ KUBECONFIG }}"
+      register: cluster_info
+    - name: Set the K8s server version
+      set_fact:
+        K8S_VERSION: "{{ cluster_info.version.server.kubernetes.major + '.' + cluster_info.version.server.kubernetes.minor }}"
+    - name: Output K8S_VERSION
+      debug:
+        msg: "{{ K8S_VERSION }}"
+  tags:
+    - baseline
+
 - name: Include ebs-csi-driver
   include_tasks: 
     file: ebs-csi-driver.yaml

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -100,12 +100,6 @@
       when:
         - tfstate.location is defined
         - tfstate.location.value|length > 0
-    - name: tfstate - kubernetes version
-      set_fact: 
-        K8S_VERSION: "{{ tfstate.k8s_version.value }}"
-      when:
-        - tfstate.k8s_version is defined
-        - tfstate.k8s_version.value|length > 0
     - name: tfstate - cluster autoscaler account
       set_fact: 
         CLUSTER_AUTOSCALER_ACCOUNT: "{{ tfstate.autoscaler_account.value }}"


### PR DESCRIPTION
### Changes
Instead of pulling the K8S server version information from an output passed in from tfstate, query the K8s server version from within DAC to remove a dependency on IAC to provide it in the AWS provider, or other providers in the future. This change should allow viya4-iac-aws releases prior to 5.2.0 to work with the latest DAC release just as before.

### Tests
Verification of this update will be run against clusters created by each IAC project.
Internal ticket comments contain dev test results with this update run against clusters created by all four IAC projects.