### PR TITLE
feat: (IAC-756): Update crunchy v5 tuning transformer

### DIFF
--- a/docs/user/Multi-Tenancy.md
+++ b/docs/user/Multi-Tenancy.md
@@ -102,6 +102,8 @@ Step 3. Onboard tenants. Run the following command:
     -e BASE_DIR=$HOME/deployments \
     -e KUBECONFIG=$HOME/deployments/.kube/config \
     -e CONFIG=$HOME/deployments/dev-cluster/dev-namespace/ansible-vars.yaml \
+    -e TFSTATE=$HOME/deployments/dev-cluster/terraform.tfstate \
+    -e JUMP_SVR_PRIVATE_KEY=$HOME/.ssh/id_rsa \
     playbooks/playbook.yaml --tags "multi-tenancy,onboard"
   ```
 **Note:** As part of setup in the above `Onboard tenants` step, for every onboarded tenant, a CAS server directory containing the configuration artifacts is created under the `/site-config` folder. 

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -85,22 +85,10 @@
     - update
 
 # Updates to support Crunchy v5 internal PostgreSQL
-- set_fact:
-    CUSTOM_CONFIGURATION: |-
-      postgresql:
-        parameters:
-          max_connections: {{ MAX_CONNECTIONS }}
-          max_prepared_transactions: {{ MAX_CONNECTIONS }}
-  when: crunchy_tuning_folder.stat.exists
-  tags:
-    - install
-    - uninstall
-    - update
-
 - name: postgres crunchy v5 - copy custom config 
   copy:
     src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-transformer.yaml"
-    dest: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    dest: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml"
     mode: "0660"
   loop_control:
     loop_var: file
@@ -114,7 +102,7 @@
 
 - name: postgres crunchy v5 - remove commented block
   lineinfile:
-    path: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml"
     regexp: '#.*$'
     state: absent
   when: 
@@ -127,12 +115,15 @@
 
 - name: postgres crunchy v5 - update config
   replace:
-    path: "{{ role_path }}/templates/transformers/{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml"
+    path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml"
     regexp: "{{ outer_item.regexp }}"
     replace: "{{ outer_item.replace }}"
   with_items:
-    - { regexp: "{% raw %}{{ CONFIGURATION }}{% endraw %}", replace: "{{ CUSTOM_CONFIGURATION | indent( width=6, first=False) }}" }
-    - { regexp: "{% raw %}{{ POSTGRESCLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform' if role == 'default' else role }}-postgres" }
+    - { regexp: "(^\n)", replace: "" }
+    - { regexp: "max_connections.*", replace: "max_connections: {{ MAX_CONNECTIONS | indent( width=6, first=False)}}" }
+    - { regexp: "max_prepared_transactions.*", replace: "max_prepared_transactions: {{ MAX_CONNECTIONS | indent( width=6, first=False)}}" }
+    - { regexp: "{% raw %}{{ TRANSFORMER-NAME }}{% endraw %}", replace: "{{ 'platform-postgres' if role == 'default' else role }}" }
+    - { regexp: "{% raw %}{{ CLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform-postgres' if role == 'default' else role }}" }
   when: 
     - crunchy_tuning_folder.stat.exists
     - settings.internal
@@ -149,7 +140,7 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { transformers: "{{ 'platform' if role == 'default' else role }}-postgres-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
+      - { transformers: "{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
   when: 
     - crunchy_tuning_folder.stat.exists
     - settings.internal


### PR DESCRIPTION
# Changes:
- Updated crunchy v5 tuning transformer. The variables and format of the tuning transformer used previously to add max_connections changed, made changes to accommodate these changes.
- Minor change to onboard run command for parity with other commands (this was somehow missed previously).

# Tests:
Verified the new tuning transformers are generated correctly for both platform postgres and cds postgres. 