### PR TITLE
fix: (IAC-758) [DAC] error message when uninstalling Viya w/o internal PG

### DIFF
--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -90,6 +90,7 @@
   ignore_errors: yes
   when:
     - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - internal_postgres
   tags:
     - uninstall
 


### PR DESCRIPTION
### Changes
Only run the uninstall postgrescluster task when an internal postgres database is present to avoid the error msg generated trying to uninstall a postgres db that's not present.

### Tests
Ran through a Viya uninstall against two deployments, one with an internal postgres db installed and one with an external postgres db installed.

|Scenario |Provider|Outcome|
|--|--|--|
|1 - Internal postgres db|Azure|Uninstall postgresclusters task runs as needed and uninstalls postgres prior to Viya uninstall|
|2- External postgres db|Azure|Uninstall postgresclusters task is skipped|