### PR TITLE
fix: (IAC-524): Modify sitedefault.yml file to include required missing ldap.connection.url property

### DIFF
--- a/examples/sitedefault.yaml
+++ b/examples/sitedefault.yaml
@@ -5,6 +5,7 @@ config:
             host: ldap-svc
             password: Password123
             port: 389
+            url: ldap://${sas.identities.providers.ldap.connection.host}:${sas.identities.providers.ldap.connection.port}
             userDN: cn=admin,dc=example,dc=com
         sas.identities.providers.ldap.group:
             baseDN: ou=groups,dc=example,dc=com
@@ -22,5 +23,4 @@ config:
             objectFilter: (objectClass=inetOrgPerson)
             searchFilter: uid={0}
         sas.logon.initial.password: Password123
-        sas.identities:
-            administrator: viya_admin
+config/identities/sas.identities/administrator: viya_admin

--- a/roles/vdm/files/sitedefault.yaml
+++ b/roles/vdm/files/sitedefault.yaml
@@ -5,6 +5,7 @@ config:
             host: ldap-svc
             password: Password123
             port: 389
+            url: ldap://${sas.identities.providers.ldap.connection.host}:${sas.identities.providers.ldap.connection.port}
             userDN: cn=admin,dc=example,dc=com
         sas.identities.providers.ldap.group:
             baseDN: ou=groups,dc=example,dc=com
@@ -22,5 +23,4 @@ config:
             objectFilter: (objectClass=inetOrgPerson)
             searchFilter: uid={0}
         sas.logon.initial.password: Password123
-        sas.identities:
-            administrator: viya_admin
+config/identities/sas.identities/administrator: viya_admin


### PR DESCRIPTION
# Changes:
Updated the sitedefault.yml file to include required missing ldap.connection.url property and the suggested format for define admin user `config/identities/sas.identities/administrator: viya_admin`

# Tests:
Ran viya4-deployment at least 3 times and verified the `viya-admin` user was prompted the SASAdministrator role. See details in internal ticket.