### PR TITLE
(iac-701) Use 'sas' as default storage class name for postgres and pgbackrest PVCs

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -241,8 +241,8 @@ V4_CFG_POSTGRES_SERVERS:
 | backrest_storage_size | Size of the internal pgBackrest PVCs | string | 128Gi | false | This value can be changed but not decreased after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | postgres_access_mode | Access mode for the PostgreSQL PVCs | string | ReadWriteOnce | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | backrest_access_mode | Access mode for the pgBackrest PVCs | string | ReadWriteOnce | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
-| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | default | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
-| backrest_storage_class | Storage class for the pgBackrest PVCs | string | default | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
+| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | sas | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
+| backrest_storage_class | Storage class for the pgBackrest PVCs | string | sas | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 
 Examples:
 

--- a/roles/vdm/templates/transformers/crunchy-storage-transformer.yaml
+++ b/roles/vdm/templates/transformers/crunchy-storage-transformer.yaml
@@ -31,12 +31,12 @@ patch: |-
   # This value cannot be changed after the initial deployment
   - op: replace
     path: /spec/instances/0/dataVolumeClaimSpec/storageClassName
-    value: {{ settings.postgres_storage_class|default('default', true) }}
+    value: {{ settings.postgres_storage_class|default('sas', true) }}
 
   # This value cannot be changed after the initial deployment
   - op: replace
     path: /spec/backups/pgbackrest/repos/0/volume/volumeClaimSpec/storageClassName
-    value: {{ settings.backrest_storage_class|default('default', true) }}
+    value: {{ settings.backrest_storage_class|default('sas', true) }}
 target:
   group: postgres-operator.crunchydata.com
   kind: PostgresCluster


### PR DESCRIPTION
### Changes
Change the default storage class name to use for postgres and pgbackrest PVCs to 'sas', a storage class  which DAC normally creates for each of the cloud environments.
### Tests
Scenarios run against Azure, AWS and GCP point to the need for this change in AWS and GCP cloud environments.