### PR TITLE
feat: (IAC-652) Update google/cloud-sdk version to 409.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 FROM baseline
 ARG HELM_VERSION=3.8.1
 ARG aws_cli_version=2.1.20
-ARG gcp_cli_version=334.0.0
+ARG gcp_cli_version=409.0.0
 
 # Add extra packages
 RUN apt install -y gzip wget git git-lfs jq sshpass \


### PR DESCRIPTION
### Changes
Update the google/cloud-sdk version in the viya4-deployent dockerfile. The new version is 409.0.0, the previous version was 334.0.0.

### Tests

See internal ticket for more details

* Built a viya4-iac-gcp docker image with the changes, and I was successfully able to create my infrastructure. 1.23.8-gke.1900
* This change also fixes a reported GitHub issue https://github.com/sassoftware/viya4-iac-gcp/issues/146
  * I was able to use the gcloud binary (as the entrypoint) in viya4-iac-gcp docker image successfully switch to authenticate without running into an invalid_request error 
* I was able to use the viya4-deployment image with the updated google/cloud-sdk to perform a Viya deployment in a GKE cluster
  * My scenario uses an external Postgres Server since that workflow involves invoking task that runs a couple of gcloud commands to set up the cloud-sql-proxy account
  * Verified that those gcloud commands worked correctly
  * Cadence: stable:2022.10, external PG