### PR TITLE
fix: (IAC-768): Adjust tuning transformer to handle front-door and tls disabled cases

### DIFF
--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -106,11 +106,12 @@
     regexp: "{{ outer_item.regexp }}"
     replace: "{{ outer_item.replace }}"
   with_items:
-    - { regexp: "#pg_hba:", replace: "pg_hba:| indent( width=4, first=False)" }
-    - { regexp: '.*$hostnossl.*$', replace: '- "hostnossl all all all md5"| indent( width=6, first=False)' }
+    - { regexp: "#pg_hba:", replace: "pg_hba:" }
+    - { regexp: '#  - "hostnossl all all all md5"', replace: ' - "hostnossl all all all md5"' }
   when: 
     - crunchy_tuning_folder.stat.exists
     - settings.internal
+    - V4_CFG_TLS_MODE in ["front-door", "disabled"]
   loop_control:
     loop_var: outer_item
   tags:

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -100,6 +100,24 @@
     - uninstall
     - update
 
+- name: postgres crunchy v5 - uncomment config for front-door or tls disabled 
+  replace:
+    path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml"
+    regexp: "{{ outer_item.regexp }}"
+    replace: "{{ outer_item.replace }}"
+  with_items:
+    - { regexp: "#pg_hba:", replace: "pg_hba:| indent( width=4, first=False)" }
+    - { regexp: '.*$hostnossl.*$', replace: '- "hostnossl all all all md5"| indent( width=6, first=False)' }
+  when: 
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: postgres crunchy v5 - remove commented block
   lineinfile:
     path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml"


### PR DESCRIPTION
# Changes:
Updated the code to make changes to tuning transformer when TLS is set to either ( front-door or disabled). Without the pg_hba setting in the tuning transformer Multi-tenant deployment fails to stabilize.

# Tests:
Verified the changes on 3 TLS scenarios on multi-tenancy enabled deployment:
1. TLS: full-stack  -- no changes, multi-tenant deployment is successful, tenants are onboarded correctly
2. TLS: front-door -- pg_hba parameter is correctly set, multi-tenant deployment is successful, tenants are onboarded correctly
3. TLS: disabled -- pg_hba parameter is correctly set, multi-tenant deployment is successful, tenants are onboarded correctly