### PR TITLE
docs: (IAC-552): Update Dependencies.md for min Docker Version

### DIFF
--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -10,7 +10,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~ | pip | 3.x |
 | ~ | unzip | any |
 | ~ | tar | any |
-| ~ | docker | any |
+| ~ | docker | >=20.10.10 |
 | ~ | git | any |
 | ~ | rsync | any |
 | ~ | kustomize | 3.7.0 |


### PR DESCRIPTION
## Change
Docker needs to be >=20.10.10 to run ubuntu:21.10 or later containers.

ref: https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921