### PR TITLE
feat: (IAC-664) Update Docker Run Calls and Create License Folder

### DIFF
--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -11,9 +11,19 @@
     - cas-onboard
     - offboard
 
+- name: assets - create license directory
+  file:
+    path: "{{ DEPLOY_DIR }}/license"
+    state: directory
+    mode: "0770"
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: assets - Get License
   command:
-    cmd: "{{ tmpdir.path }}/viya4-orders-cli license --file-path {{ DEPLOY_DIR }}/site-config --file-name license {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
+    cmd: "{{ tmpdir.path }}/viya4-orders-cli license --file-path {{ DEPLOY_DIR }}/license --file-name license {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
   environment:
     CLIENTCREDENTIALSID: "{{ V4_CFG_SAS_API_KEY | string | b64encode }}"
     CLIENTCREDENTIALSSECRET: "{{ V4_CFG_SAS_API_SECRET | string | b64encode }}"
@@ -26,7 +36,7 @@
 
 - name: assets - Get Certificates
   command:
-    cmd: "{{ tmpdir.path }}/viya4-orders-cli certificates --file-path {{ tmpdir.path }}/ --file-name certs {{ V4_CFG_ORDER_NUMBER }}"
+    cmd: "{{ tmpdir.path }}/viya4-orders-cli certificates --file-path {{ DEPLOY_DIR }}/license/ --file-name certs {{ V4_CFG_ORDER_NUMBER }}"
   environment:
     CLIENTCREDENTIALSID: "{{ V4_CFG_SAS_API_KEY | string | b64encode }}"
     CLIENTCREDENTIALSSECRET: "{{ V4_CFG_SAS_API_SECRET | string | b64encode }}"
@@ -99,7 +109,7 @@
 - name: assets - Copy user-provided license file
   copy:
     src: "{{ V4_CFG_LICENSE}}"
-    dest: "{{ DEPLOY_DIR }}/site-config/license.jwt"
+    dest: "{{ DEPLOY_DIR }}/license/license.jwt"
   when:
     - V4_CFG_LICENSE is not none
   tags:

--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -55,22 +55,18 @@
       when:
         - deployment_tooling == "docker"
     - name: deploy - Deploy SAS Viya
-      community.docker.docker_container:
-        name: "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
-        image: "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        volumes:
-          - "{{ ORCHESTRATION_TOOLING_INSTALL_MANIFESTS_DIRECTORY }}:/manifests"
-          - "{{ KUBECONFIG }}:/config/kubeconfig"
-        detach: false
-        cleanup: yes
-        user: "{{ UID_GID }}"
-        env:
-          KUBECONFIG: "/config/kubeconfig"
-          WORK_DIRECTORY: "/tmp/work"
-        command:
-          - "deploy"
-          - "--namespace {{ NAMESPACE }}"
-          - "--sas-deployment-cr {{ item.path | replace(ORCHESTRATION_TOOLING_DIRECTORY, '/') }}"
+      ansible.builtin.shell: >
+        docker run --rm
+        --user="{{ UID_GID }}"
+        --name "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+        --env KUBECONFIG="/config/kubeconfig"
+        --env WORK_DIRECTORY="/tmp/work"
+        --volume "{{ ORCHESTRATION_TOOLING_INSTALL_MANIFESTS_DIRECTORY }}:/manifests"
+        --volume "{{ KUBECONFIG }}:/config/kubeconfig"
+        "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
+        deploy
+        --namespace {{ NAMESPACE }}
+        --sas-deployment-cr {{ item.path | replace(ORCHESTRATION_TOOLING_DIRECTORY, '/') }}
       with_items:
         - "{{ deployment_manifests.files }}"
       when:

--- a/roles/vdm/tasks/orchestration.yaml
+++ b/roles/vdm/tasks/orchestration.yaml
@@ -180,6 +180,10 @@
         path: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work/"
         state: directory
         mode: "0700"
+    - name: orchestration - Copy licenses into orchestration tooling directory
+      copy:
+        src: "{{ DEPLOY_DIR }}/license"
+        dest: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data"
     - name: orchestration - Copy site-config into orchestration tooling directory
       synchronize:
         src: "{{ DEPLOY_DIR }}/site-config"
@@ -211,7 +215,7 @@
             --cadence-version "{{ V4_CFG_CADENCE_VERSION }}"
             --cadence-release "{{ V4_CFG_CADENCE_RELEASE }}"
             --image-registry "{{ V4_CFG_CR_HOST }}"
-            --deployment-data "{{ tmpdir.path }}/certs.zip"
+            --deployment-data "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data/license/certs.zip"
             --user-content "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data/"
       args:
         chdir: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}"
@@ -231,46 +235,28 @@
 
 - name: orchestration - SAS Viya deployment manifest - Ansible
   block:
-    - name: orchestration - Generate SAS Viya deployment manifest
-      community.docker.docker_container:
-        name: "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
-        image: "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        volumes:
-          - "{{ tmpdir.path }}:/tmp"
-          - "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data:/data"
-          - "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
-        detach: false
-        cleanup: yes
-        user: "{{ UID_GID }}"
-        command:
-          - "create sas-deployment-cr"
-          - "--cadence-name {{ V4_CFG_CADENCE_NAME }}"
-          - "--cadence-version {{ V4_CFG_CADENCE_VERSION }}"
-          - "--cadence-release {{ V4_CFG_CADENCE_RELEASE }}"
-          - "--image-registry {{ V4_CFG_CR_HOST }}"
-          - "--deployment-data /tmp/certs.zip"
-          - "--user-content /data"
+    - name: orchestration - Generate SAS Viya deployment manifest NEW
+      ansible.builtin.shell: >
+        docker run --rm
+        --user="{{ UID_GID }}"
+        --name "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+        --volume "{{ tmpdir.path }}:/tmp"
+        --volume "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data:/data"
+        --volume "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
+        "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
+        create sas-deployment-cr
+        --cadence-name {{ V4_CFG_CADENCE_NAME }}
+        --cadence-version {{ V4_CFG_CADENCE_VERSION }}
+        --cadence-release {{ V4_CFG_CADENCE_RELEASE }}
+        --image-registry {{ V4_CFG_CR_HOST }}
+        --deployment-data /data/license/certs.zip
+        --user-content /data
       register: sasdeployment
     - name: orchestration - Write SAS Viya deployment manifest
       copy:
-        content: "{{ sasdeployment.container.Output }}"
+        content: "{{ sasdeployment.stdout }}"
         dest: "{{ ORCHESTRATION_TOOLING_INSTALL_MANIFEST }}"
         mode: "0660"
-  when:
-    - deployment_tooling == "ansible"
-  tags:
-    - install
-    - update
-    - cas-onboard
-    - offboard
-
-# At the moment there is no way to split the stderr from the container output
-# so regex is used to remove the extra lines
-- name: Clean up ORCHESTRATION_TOOLING_INSTALL_MANIFEST
-  lineinfile:
-    path: "{{ ORCHESTRATION_TOOLING_INSTALL_MANIFEST }}"
-    state: absent
-    regexp: '^The create sas-deployment-cr command.*$'
   when:
     - deployment_tooling == "ansible"
   tags:
@@ -339,7 +325,7 @@
             --cadence-version "{{ V4_CFG_CADENCE_VERSION }}"
             --cadence-release "{{ V4_CFG_CADENCE_RELEASE }}"
             --image-registry "{{ V4_CFG_CR_HOST }}"
-            --deployment-data "{{ tmpdir.path }}/certs.zip"
+            --deployment-data "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data/license/certs.zip"
             --user-content "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data/"
       args:
         chdir: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}"
@@ -359,28 +345,25 @@
 - name: orchestration - Create SAS Viya uninstall manifest V4_DEPLOYMENT_OPERATOR_ENABLED - Ansible
   block:
     - name: orchestration - Generate SAS Viya uninstall manifest
-      community.docker.docker_container:
-        name: "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
-        image: "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        volumes:
-          - "{{ tmpdir.path }}:/tmp"
-          - "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data:/data"
-          - "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
-        detach: false
-        cleanup: yes
-        user: "{{ UID_GID }}"
-        command:
-          - "create sas-deployment-cr"
-          - "--cadence-name {{ V4_CFG_CADENCE_NAME }}"
-          - "--cadence-version {{ V4_CFG_CADENCE_VERSION }}"
-          - "--cadence-release {{ V4_CFG_CADENCE_RELEASE }}"
-          - "--image-registry {{ V4_CFG_CR_HOST }}"
-          - "--deployment-data /tmp/certs.zip"
-          - "--user-content /data"
+      ansible.builtin.shell: >
+        docker run --rm
+        --user="{{ UID_GID }}"
+        --name "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+        --volume "{{ tmpdir.path }}:/tmp"
+        --volume "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/data:/data"
+        --volume "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
+        "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
+        create sas-deployment-cr
+        --cadence-name {{ V4_CFG_CADENCE_NAME }}
+        --cadence-version {{ V4_CFG_CADENCE_VERSION }}
+        --cadence-release {{ V4_CFG_CADENCE_RELEASE }}
+        --image-registry {{ V4_CFG_CR_HOST }}
+        --deployment-data /data/license/certs.zip
+        --user-content /data
       register: sasdeployment
     - name: orchestration - Write SAS Viya uninstall manifest
       copy:
-        content: "{{ sasdeployment.container.Output }}"
+        content: "{{ sasdeployment.stdout }}"
         dest: "{{ ORCHESTRATION_TOOLING_UNINSTALL_MANIFEST }}"
         mode: "0660"
   when:
@@ -416,39 +399,23 @@
 - name: orchestration - Create SAS Viya uninstall manifest - Ansible
   block:
     - name: orchestration - Generate SAS Viya uninstall manifest
-      community.docker.docker_container:
-        name: "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
-        image: "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        volumes:
-          - "{{ DEPLOY_DIR }}:/data"
-          - "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
-        detach: false
-        cleanup: yes
-        user: "{{ UID_GID }}"
-        entrypoint:
-          - "kustomize"
-        command:
-          - "build /data"
+      ansible.builtin.shell: >
+        docker run --rm
+        --user="{{ UID_GID }}"
+        --name "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+        --volume "{{ DEPLOY_DIR }}:/data"
+        --volume "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work:/work"
+        "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
+        --entrypoint kustomize
+        build /data
       register: uninstall
     - name: orchestration - Write SAS Viya uninstall manifest
       copy:
-        content: "{{ uninstall.container.Output }}"
+        content: "{{ uninstall.stdout }}"
         dest: "{{ ORCHESTRATION_TOOLING_UNINSTALL_MANIFEST }}"
         mode: "0660"
   when:
     - V4_DEPLOYMENT_OPERATOR_ENABLED == False
-    - deployment_tooling == "ansible"
-  tags:
-    - uninstall
-
-# At the moment there is no way to split the stderr from the container output
-# so regex is used to remove the extra lines
-- name: Clean up ORCHESTRATION_TOOLING_UNINSTALL_MANIFEST
-  lineinfile:
-    path: "{{ ORCHESTRATION_TOOLING_UNINSTALL_MANIFEST }}"
-    state: absent
-    regexp: '^The create sas-deployment-cr command.*$'
-  when:
     - deployment_tooling == "ansible"
   tags:
     - uninstall

--- a/roles/vdm/templates/generators/sas-license.yaml
+++ b/roles/vdm/templates/generators/sas-license.yaml
@@ -5,4 +5,4 @@ metadata:
 behavior: merge
 type: sas.com/license
 files:
-  - SAS_LICENSE=site-config/license.jwt
+  - SAS_LICENSE=license/license.jwt


### PR DESCRIPTION
## Changes
The addition of "license" folder, this will live underneath the DEPLOY_DIR and it will contain the certs and license.jwt file. The license.jwt currently exists under site-config. This is so the structure is more in line in the SAS Documentation.

Swapped out the usage of `community.docker.docker_container` to run the orchestration docker container to instead use `ansible.builtin.shell`. The older module did not have a way to split stdout from stderr and included lines we did not need in the generated CRD .

## Tests
See internal ticket.
| Scenario | Provider | K8s Version | Order | Docker | Cadence | DO Enabled | Deployment Stabilized  |  
|---|---|---|---|---|---|---|---|
| 1 | Azure | v1.23.8 | * | With Docker | stable:2022.11 | yes | yes  |  
| 2 | GCP | v1.24.4-gke.800 | *| With Docker | stable:2022.11 | no | yes  |  
| 3 | GCP | v1.24.4-gke.800 | *| Without Docker | stable:2022.11 | yes | yes  |  
| 4 | Azure | v1.23.8 | *| Without Docker | stable:2022.11 | no | yes  |  