### PR TITLE
feat: (IAC-439): Make NLB to be default load balancer for AWS

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -62,6 +62,13 @@ INGRESS_NGINX_CONFIG:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
 
+# Update default load-balancer for AWS to be NLB
+INGRESS_NGINX_AWS_NLB_CONFIG:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
 # Ingress-nginx - CVE-2021-25742 Mitigation
 INGRESS_NGINX_CVE_2021_25742_PATCH:
   controller:

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,6 +28,15 @@
     - install
     - update
 
+- name: Update INGRESS_NGINX_CONFIG to use NLB for AWS
+  set_fact:
+    INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_AWS_NLB_CONFIG, recursive=True)}}"
+  when:
+    - PROVIDER == "aws"
+  tags:
+    - install
+    - update
+
 - name: Apply Mitigation for CVE-2021-25742
   block:
     - name: Retreive K8s cluster information


### PR DESCRIPTION
# Changes:
With the CLB retiring, this change will enable NLB as the default load-balancer that gets deployed for AWS.

# Tests:
Verified following scenarios on AWS EKS cluster. See details in internal ticket:

|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Defaults, no additional annotations|Fast 2020|NLB load-balancer was created. Viya4 deployment stabilized and was accessible|
|2|Specified additional annotations|Stable 2022.11|NLB load-balancer was created along with the additional annotations. Viya4 deployment stabilized and was accessible|
|3|Specified additional annotations along with aws-load-balancer-type: nlb|Fast 2020|NLB load-balancer was created along with the additional annotations. NLB annotation wasn’t duplicated. Viya4 deployment stabilized and was accessible|
