### PR TITLE
feat: (IAC-770) use k8s.core.k8s_info module not kubectl to avoid ansible error output

### DIFF
--- a/roles/vdm/tasks/postgres/pg_config.yaml
+++ b/roles/vdm/tasks/postgres/pg_config.yaml
@@ -31,18 +31,24 @@
 - name: pg_config - v4 crunchy operator check
   block:
   - name: pg_config - Find v4 crunchy deployment
-    ansible.builtin.shell: |
-      kubectl --kubeconfig {{ KUBECONFIG }} get deployment -n {{ NAMESPACE }} |grep sas-crunchy-data-postgres-operator
-    register: find_op
-    ignore_errors: true
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ KUBECONFIG }}"
+      kind: Deployment
+      name: sas-crunchy-data-postgres-operator
+      namespace: "{{ NAMESPACE }}"
+    register: deploy
   - name: pg_config - v4 crunchy operator found
     set_fact:
       v4_crunchy_present: true
-    when: "find_op.rc == 0"
+    when: 
+      - deploy.resources is defined
+      - deploy.resources | length != 0
   - name: pg_config - v4 crunchy operator not found
     set_fact:
       v4_crunchy_present: false
-    when: "find_op.rc != 0"
+    when: 
+      - deploy.resources is defined
+      - deploy.resources | length == 0
   when:
     - not dac_crunchy_storage_cm_found
   tags:


### PR DESCRIPTION
### Changes
Substitute using an ansible kubernetes.core.k8s_info module query as opposed to the builtin.shell "kubectl | grep" command to avoid generating "red" Ansible error output that requires ignoring and can cause questions or concerns for end users.
### Testing
Ran through a deployment with Viya uninstalled and two separate redeployments against clusters with v4 crunchy installed and a redeployment on a cluster with v5 crunchy installed to verify that the v4_crunchy_present fact was being set properly to true or false for the version of crunchy installed.