### PR TITLE
fix: (IAC-836): Updated assets.yaml to include cas-onboard tag 

### DIFF
--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -8,8 +8,6 @@
     - install
     - uninstall
     - update
-    - cas-onboard
-    - offboard
 
 - name: assets - Set facts
   set_fact:
@@ -18,6 +16,8 @@
     - install
     - uninstall
     - update
+    - cas-onboard
+    - offboard
 
 - name: assets - create license directory
   file:
@@ -52,8 +52,6 @@
     - install
     - uninstall
     - update
-    - cas-onboard
-    - offboard
 
 - name: assets - Download
   command:


### PR DESCRIPTION
# Changes:
With the updates made to DO code to change the path for license directory, the `LICENSE_DIRECTORY` fact was missing when multi-tenancy cas-onboard task was applied.
- Updated the assset.yaml file to include `cas-onboard` and `offboard` tag for setting the `LICENSE_DIRECTORY` fact.
- Also removed the `cas-onboard` and `offboard` tag from not required tasks which were accidentally included before.

# Tests:
- Verified the onboard and cas-onboard of tenants is successful
- Also verified offboard of tenants was successful