### PR TITLE
docs: (IAC-837) Add clarification text for V4_CFG_MANAGE_STORAGE settings

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -74,7 +74,7 @@ Supported configuration variables are listed in the table below.  All variables 
 | V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH | Full path to service account credentials file | string | | false | See [Ansible Cloud Authentication](user/AnsibleCloudAuthentication.md) for more information. | viya |
 
 ## Jump Server
-Viya4-deploy uses the jump server to interact with the RWX filestore, which must be pre-mounted to JUMP_SVR_RWX_FILESTORE_PATH when V4_CFG_MANAGE_STORAGE is set to `true`.
+Viya4-deployment uses the jump server to interact with the RWX filestore, which must be pre-mounted to `JUMP_SVR_RWX_FILESTORE_PATH` when `V4_CFG_MANAGE_STORAGE` is set to `true`.
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -84,14 +84,16 @@ Viya4-deploy uses the jump server to interact with the RWX filestore, which must
 | JUMP_SVR_RWX_FILESTORE_PATH | Path on the jump server to the NFS mount | string | /viya-share | false | | viya |
 
 ## Storage
-When V4_CFG_MANAGE_STORAGE is set to true, Viya4-deploy will create the "sas" and "pg-storage" storage classes using the nfs-subdir-external-provisioner helm chart for the Viya deployment to use. If a jump server is present, Viya4-deploy will use that server to create the folders for the ASTORES, BIN, DATA and HOMES RWX Filestore NFS paths outlined in the RWX Filestore section below. 
+When `V4_CFG_MANAGE_STORAGE` is set to `true`, viya4-deployment creates the `sas` and `pg-storage` storage classes using the nfs-subdir-external-provisioner Helm chart. If a jump server is used, viya4-deployment uses that server to create the folders for the `astores`, `bin`, `data` and `homes` RWX Filestore NFS paths that are outlined below in the [RWX Filestore](#rwx-filestore) section.
 
-When V4_CFG_MANAGE_STORAGE is set to false, Viya4-deploy will not create the "sas" or "pg-storage" storage classes. Viya4-deploy will also not create or manage the RWX Filestore NFS paths for you. If V4_CFG_MANAGE_STORAGE is set to false, the values for V4_CFG_RWX_FILESTORE_ASTORES_PATH,
-V4_CFG_RWX_FILESTORE_BIN_PATH, V4_CFG_RWX_FILESTORE_DATA_PATH and V4_CFG_RWX_FILESTORE_HOMES_PATH must be set to existing NFS folder locations prior to running a Viya deployment. The required NFS folders can be created from the jump server by the Viya4-deploy user prior to running a Viya4 deployment. Recommended attribute settings for each folder are as follows: set the filemode to 0777, group to 'nogroup' and owner to 'nobody'.
+When `V4_CFG_MANAGE_STORAGE` is set to `false`, viya4-deployment does not create the `sas` or `pg-storage` storage classes for you. In addition, viya4-deployment does not create or manage the RWX Filestore NFS paths. Before you run the SAS Viya deployment, you must set the values for `V4_CFG_RWX_FILESTORE_ASTORES_PATH`, `V4_CFG_RWX_FILESTORE_BIN_PATH`, `V4_CFG_RWX_FILESTORE_DATA_PATH` and `V4_CFG_RWX_FILESTORE_HOMES_PATH` to specify existing NFS folder locations. The viya4-deployment user can create the required NFS folders from the jump server before starting the deployment. Recommended attribute settings for each folder are as follows: 
+- **filemode**: `0777` 
+- **group**: the equivalent of `nogroup` for your operating system 
+- **owner**: `nobody`
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_MANAGE_STORAGE | Whether viya4-deploy should manage the StorageClass | bool | true | false | Set to false if you want to manage the StorageClass yourself. | all |
+| V4_CFG_MANAGE_STORAGE | Whether viya4-deployment should manage the StorageClass | bool | true | false | Set to false if you want to manage the StorageClass yourself. | all |
 | V4_CFG_STORAGECLASS | StorageClass name | string | "sas" | false | When V4_CFG_MANAGE_STORAGE is false, set to the name of your preexisting StorageClass that supports ReadWriteMany. | baseline, viya |
 
 ### RWX Filestore
@@ -260,8 +262,8 @@ V4_CFG_POSTGRES_SERVERS:
 | backrest_pvc_storage_size | Size of the internal pgBackrest PVCs | string | 128Gi | false | This value can be changed but not decreased after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | postgres_pvc_access_mode | Access mode for the PostgreSQL PVCs | string | ReadWriteOnce | false | Supported values: [`ReadWriteOnce`,`ReadWriteMany`]. This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | backrest_pvc_access_mode | Access mode for the pgBackrest PVCs | string | ReadWriteOnce | false | Supported values: [`ReadWriteOnce`,`ReadWriteMany`]. This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
-| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. Set to the name of your pre-existing StorageClass or set V4_CFG_MANAGE_STORAGE to true to have Viya4-deploy create the pg-storage StorageClass. | viya |
-| backrest_storage_class | Storage class for the pgBackrest PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. Set to the name of your pre-existing StorageClass or set V4_CFG_MANAGE_STORAGE to true to have Viya4-deploy create the pg-storage StorageClass. | viya |
+| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. The default value is only used if `V4_CFG_MANAGE_STORAGE` is set to `true`. If `V4_CFG_MANAGE_STORAGE` is set to false, set the value to your pre-existing StorageClass name. | viya |
+| backrest_storage_class | Storage class for the pgBackrest PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. The default value is only used if `V4_CFG_MANAGE_STORAGE` is set to `true`. If `V4_CFG_MANAGE_STORAGE` is set to false, set the value to your pre-existing StorageClass name. | viya |
 
 **NOTE**: the `default` element is always required. This will be the default server.
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -84,6 +84,10 @@ Viya4-deploy uses the jump server to interact with the RWX filestore, which must
 | JUMP_SVR_RWX_FILESTORE_PATH | Path on the jump server to the NFS mount | string | /viya-share | false | | viya |
 
 ## Storage
+When V4_CFG_MANAGE_STORAGE is set to true, Viya4-deploy will create the "sas" and "pg-storage" storage classes using the nfs-subdir-external-provisioner helm chart for the Viya deployment to use. If a jump server is present, Viya4-deploy will use that server to create the folders for the ASTORES, BIN, DATA and HOMES RWX Filestore NFS paths outlined in the RWX Filestore section below. 
+
+When V4_CFG_MANAGE_STORAGE is set to false, Viya4-deploy will not create the "sas" or "pg-storage" storage classes. Viya4-deploy will also not create or manage the RWX Filestore NFS paths for you. If V4_CFG_MANAGE_STORAGE is set to false, the values for V4_CFG_RWX_FILESTORE_ASTORES_PATH,
+V4_CFG_RWX_FILESTORE_BIN_PATH, V4_CFG_RWX_FILESTORE_DATA_PATH and V4_CFG_RWX_FILESTORE_HOMES_PATH must be set to existing NFS folder locations prior to running a Viya deployment. The required NFS folders can be created from the jump server by the Viya4-deploy user prior to running a Viya4 deployment. Recommended attribute settings for each folder are as follows: set the filemode to 0777, group to 'nogroup' and owner to 'nobody'.
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -256,8 +260,8 @@ V4_CFG_POSTGRES_SERVERS:
 | backrest_pvc_storage_size | Size of the internal pgBackrest PVCs | string | 128Gi | false | This value can be changed but not decreased after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | postgres_pvc_access_mode | Access mode for the PostgreSQL PVCs | string | ReadWriteOnce | false | Supported values: [`ReadWriteOnce`,`ReadWriteMany`]. This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
 | backrest_pvc_access_mode | Access mode for the pgBackrest PVCs | string | ReadWriteOnce | false | Supported values: [`ReadWriteOnce`,`ReadWriteMany`]. This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
-| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
-| backrest_storage_class | Storage class for the pgBackrest PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases.| viya |
+| postgres_storage_class | Storage class for the PostgreSQL PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. Set to the name of your pre-existing StorageClass or set V4_CFG_MANAGE_STORAGE to true to have Viya4-deploy create the pg-storage StorageClass. | viya |
+| backrest_storage_class | Storage class for the pgBackrest PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. Set to the name of your pre-existing StorageClass or set V4_CFG_MANAGE_STORAGE to true to have Viya4-deploy create the pg-storage StorageClass. | viya |
 
 **NOTE**: the `default` element is always required. This will be the default server.
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -265,7 +265,7 @@ V4_CFG_POSTGRES_SERVERS:
 | postgres_storage_class | Storage class for the PostgreSQL PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. The default value is only used if `V4_CFG_MANAGE_STORAGE` is set to `true`. If `V4_CFG_MANAGE_STORAGE` is set to false, set the value to your pre-existing StorageClass name. | viya |
 | backrest_storage_class | Storage class for the pgBackrest PVCs | string | pg-storage | false |This value cannot be changed after the initial deployment. Supported for cadence versions 2022.10 and later. Only for internal databases. The default value is only used if `V4_CFG_MANAGE_STORAGE` is set to `true`. If `V4_CFG_MANAGE_STORAGE` is set to false, set the value to your pre-existing StorageClass name. | viya |
 
-**NOTE**: the `default` element is always required. This will be the default server.
+**NOTE**: The `default` element is always required. This will be the default server.
 
 Examples:
 


### PR DESCRIPTION
### Change
Create the draft of new doc to be added to the `Storage` and `PostgreSQL` sections of CONFIG-VARS.md to help explain viya4-deploy behavior and expectations when setting values for the `V4_CFG_MANAGE_STORAGE` variable.