### PR TITLE
feat: (IAC-693) Update kustomization.yaml indentation

### DIFF
--- a/roles/multi-tenancy/tasks/onboard-offboard-cas-servers.yaml
+++ b/roles/multi-tenancy/tasks/onboard-offboard-cas-servers.yaml
@@ -3,7 +3,7 @@
 - name: check if cas resources present
   lineinfile:
     path: "{{ DEPLOY_DIR }}/kustomization.yaml"
-    line: "  - site-config/cas-{{ item | trim }}-default"
+    line: "- site-config/cas-{{ item | trim }}-default"
     state: present
   check_mode: yes
   register: out
@@ -15,7 +15,7 @@
   lineinfile:
     path: "{{ DEPLOY_DIR }}/kustomization.yaml"
     insertafter: "resources:" 
-    line: "  - site-config/cas-{{ item | trim }}-default"
+    line: "- site-config/cas-{{ item | trim }}-default"
     state: present
   with_items: "{{ V4MT_TENANT_IDS.split(',') }}"
   when: out.changed

--- a/roles/vdm/templates/kustomization.yaml
+++ b/roles/vdm/templates/kustomization.yaml
@@ -8,19 +8,19 @@ namespace: {{ NAMESPACE }}
 {% if 'pre' in ordered_overlays.result[resource] and ordered_overlays.result[resource]['pre']|length > 0 %}
 ## vdm defined {{ resource }} (pre)
 {% for overlay in ordered_overlays.result[resource]['pre'] %}
-  - {{ overlay |dirname }}/{{ overlay | basename | regex_replace('\\..*\\.yaml$', '.yaml') }}
+- {{ overlay |dirname }}/{{ overlay | basename | regex_replace('\\..*\\.yaml$', '.yaml') }}
 {% endfor %}
 {% endif %}
 {% if resource in user_customizations.overlays %}
 ## user defined {{ resource }}
 {% for item in user_customizations.overlays[resource]|sort %}
-  - {{ item }}
+- {{ item }}
 {% endfor %}
 {% endif %}
 {% if 'post' in ordered_overlays.result[resource] and ordered_overlays.result[resource]['post']|length > 0 %}
 ## vdm defined {{ resource }} (post)
 {% for overlay in ordered_overlays.result[resource]['post'] %}
-  - {{ overlay |dirname }}/{{ overlay | basename | regex_replace('\\..*\\.yaml$', '.yaml') }}
+- {{ overlay |dirname }}/{{ overlay | basename | regex_replace('\\..*\\.yaml$', '.yaml') }}
 {% endfor %}
 {% endif %}
 
@@ -30,7 +30,7 @@ namespace: {{ NAMESPACE }}
 components:
 ## user defined components
 {% for item in user_customizations.overlays['components']|sort %}
-  - {{ item }}
+- {{ item }}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
### Changes
Update the indentation in the kustomization.yaml file so it's more in line with the SAS documentation.

See: https://go.documentation.sas.com/doc/en/sasadmincdc/v_035/dplyml0phy0dkr/n0g237aqo6pz1in1t19wjb94j9bi.htm#n08dvkro120s4on1g8wbqxpbcspt 

### Tests

After updating the indentation in our kustomization.yaml template, I ran through the following scenarios to verify that the generated kustomization.yaml file now has spacing that matches the SAS documentation and that Viya still deploys correctly.
I specifically ran through a MT scenario since we have some logic that does regex operations on the kustomization.yaml when onboarding/offboarding tenants

| Scenario | Cloud | K8s Version     | Deploy Method | Orchestration | Order  | Cadence   | Notes         |
|----------|-------|-----------------|---------------|---------------|--------|-----------|---------------|
| 1        | GCP   | 1.23.14-gke.401 | Ansible       | DO            | *** | fast:2020 |               |    
| 2        | GCP   | 1.23.14-gke.401 | Ansible       | DO            | *** | fast:2020 | MT Deployment |     
