### PR TITLE
feat: (IAC-720) Update \site-config\vdm\transformers with sas-bases\examples

### DIFF
--- a/roles/vdm/tasks/storage.yaml
+++ b/roles/vdm/tasks/storage.yaml
@@ -18,10 +18,10 @@
     existing: "{{ vdm_overlays }}"
     add:
       - { transformers: "cas-add-nfs-mount.yaml", vdm: true }
-      - { transformers: "compute-server-add-nfs-mount.yaml", max: "2022.1.4", vdm: true }
-      - { transformers: "compute-server-add-nfs-mount.v2.yaml", min: "2022.09", vdm: true }
-      - { transformers: "launcher-service-add-nfs.yaml", max: "2022.1.4", vdm: true }
-      - { transformers: "launcher-nfs-mount.yaml", min: "2022.09", vdm: true }
+      - { transformers: "compute-server-add-nfs-mount.yaml", max: "2021.1.6", vdm: true }
+      - { transformers: "compute-server-add-nfs-mount.v2.yaml", min: "2021.2", vdm: true }
+      - { transformers: "launcher-service-add-nfs.yaml", max: "2021.1.6", vdm: true }
+      - { transformers: "launcher-nfs-mount.yaml", min: "2021.2", vdm: true }
   when:
     - V4_CFG_RWX_FILESTORE_ENDPOINT is not none
     - V4_CFG_RWX_FILESTORE_PATH is not none

--- a/roles/vdm/tasks/storage.yaml
+++ b/roles/vdm/tasks/storage.yaml
@@ -18,8 +18,10 @@
     existing: "{{ vdm_overlays }}"
     add:
       - { transformers: "cas-add-nfs-mount.yaml", vdm: true }
-      - { transformers: "compute-server-add-nfs-mount.yaml", vdm: true }
-      - { transformers: "launcher-service-add-nfs.yaml", vdm: true }
+      - { transformers: "compute-server-add-nfs-mount.yaml", max: "2022.1.4", vdm: true }
+      - { transformers: "compute-server-add-nfs-mount.v2.yaml", min: "2022.09", vdm: true }
+      - { transformers: "launcher-service-add-nfs.yaml", max: "2022.1.4", vdm: true }
+      - { transformers: "launcher-nfs-mount.yaml", min: "2022.09", vdm: true }
   when:
     - V4_CFG_RWX_FILESTORE_ENDPOINT is not none
     - V4_CFG_RWX_FILESTORE_PATH is not none

--- a/roles/vdm/templates/transformers/cas-add-nfs-mount.yaml
+++ b/roles/vdm/templates/transformers/cas-add-nfs-mount.yaml
@@ -33,12 +33,12 @@ patch: |-
     path: /spec/controllerTemplate/spec/containers/0/volumeMounts/-
     value:
       name: nfs-data
-      mountPath: /mnt/viya-share/data
+      mountPath: {{ V4_CFG_RWX_FILESTORE_DATA_PATH }}
   - op: add
     path: /spec/controllerTemplate/spec/containers/0/volumeMounts/-
     value:
       name: nfs-homes
-      mountPath: /mnt/viya-share/homes
+      mountPath: {{ V4_CFG_RWX_FILESTORE_HOMES_PATH }}
 target:
   group: viya.sas.com
   kind: CASDeployment

--- a/roles/vdm/templates/transformers/compute-server-add-nfs-mount.v2.yaml
+++ b/roles/vdm/templates/transformers/compute-server-add-nfs-mount.v2.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: compute-server-add-nfs-mount
+patch: |-
+  - op: add
+    path: /template/spec/volumes/-
+    value:
+      name: nfs-data
+      nfs:
+        path: {{ V4_CFG_RWX_FILESTORE_DATA_PATH  }}
+        server: {{ V4_CFG_RWX_FILESTORE_ENDPOINT }}
+  - op: add
+    path: /template/spec/containers/0/volumeMounts/-
+    value:
+      mountPath: /mnt/viya-share/data
+      name: nfs-data
+target:
+  kind: PodTemplate
+  version: v1
+  labelSelector: sas.com/template-intent=sas-launcher

--- a/roles/vdm/templates/transformers/launcher-nfs-mount.yaml
+++ b/roles/vdm/templates/transformers/launcher-nfs-mount.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: sas-launcher-nfs-mount
+patch: |-
+  - op: add
+    path: /metadata/annotations/launcher.sas.com~1nfs-server
+    value: {{ V4_CFG_RWX_FILESTORE_ENDPOINT }}
+target:
+  kind: PodTemplate
+  labelSelector: sas.com/template-intent=sas-launcher


### PR DESCRIPTION
### Changes
- Refresh CAS and compute storage related transformers with the latest versions
- Remove nfs-homes patch from compute-server-add-nfs-mount transformer in .v2 version, now handled by launcher-nfs-mount transformer
- Use launcher-nfs-mount transformer with updated compute nfs-homes support in favor of launcher-service-add-nfs transformer 
- Use NFS server filestore homes path in cas-add-nfs-mount transformer allowing CAS access to nfs-homes volume
- Use and apply the updated transformers with the latest SAS Viya LTS version that provided support for them

### Testing
Following the steps documented in [SAS Viya: making user home directories available to compute](https://communities.sas.com/t5/SAS-Communities-Library/SAS-Viya-making-user-home-directories-available-to-compute/ta-p/717561?lightbox-message-images-717561=54384i17968D11962ED37D), I provisioned two different clusters, one using Azure's NetApp highly available storage for backend NFS support (storage_type="ha"), the second using an NFS VM server created via IAC (storage_type="standard") and then deployed SAS Viya to each environment. For each deployment, SAS Studio log output and results from executing the GEL provided SAS code demonstrated that both SAS Studio compute and the default CAS server were able to access and use the SAS Viya user's nfs-homes folder as documented in the SAS Communities blog. See the internal ticket for dev test execution details.
