### PR TITLE
feat: (IAC-439): Revert NLB changes

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -62,13 +62,6 @@ INGRESS_NGINX_CONFIG:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
 
-# Update default load-balancer for AWS to be NLB
-INGRESS_NGINX_AWS_NLB_CONFIG:
-  controller:
-    service:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
-
 # Ingress-nginx - CVE-2021-25742 Mitigation
 INGRESS_NGINX_CVE_2021_25742_PATCH:
   controller:

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -28,15 +28,6 @@
     - install
     - update
 
-- name: Update INGRESS_NGINX_CONFIG to use NLB for AWS
-  set_fact:
-    INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_AWS_NLB_CONFIG, recursive=True)}}"
-  when:
-    - PROVIDER == "aws"
-  tags:
-    - install
-    - update
-
 - name: Apply Mitigation for CVE-2021-25742
   block:
     - name: Retreive K8s cluster information


### PR DESCRIPTION
Reverting the changes previously made in PR #349.

**Reason for reverting:** There are few other LBs in DaC namely, V4_CFG_CAS_ENABLE_LOADBALANCER, V4_CFG_CONNECT_ENABLE_LOADBALANCER, V4_CFG_CONSUL_ENABLE_LOADBALANCER. These LBs still seem to be creating the CLB instead of NLB need to readdress the ticket and make sure all the LBs are shifted to using NLB.