### PR TITLE
feat: (IAC-876): Update tenant job name to support kustomize 4.5.7

### DIFF
--- a/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
@@ -31,6 +31,21 @@
     - onboard
     - offboard
 
+# Update the job names to unique identifier - required for Kustomize v4.5.7+
+- name: sas-tenant-job - update job-name
+  replace:
+    path: "{{ item.path }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { path: '{{ DEPLOY_DIR }}/site-config/sas-tenant-job/tenant-onboard-job.yaml', regexp: '{% raw %}{{ JOB-TAG }}{% endraw %}', replace: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}" }
+    - { path: '{{ DEPLOY_DIR }}/site-config/sas-tenant-job/tenant-offboard-job.yaml', regexp: '{% raw %}{{ JOB-TAG }}{% endraw %}', replace: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}" }
+  when: 
+    - V4MT_ENABLE
+    - V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  tags:
+    - onboard
+    - offboard
 
 - name: sas-tenant-job - update sas-tenant-ids
   replace:


### PR DESCRIPTION
# Changes:
Kustomize v4.5.7+ does not support the generateNames field. So the new requirement is to add unique identifiers to the tenant job names to avoid failures later in the process.

# Tests:
Verified following scenarios, see details in internal ticket:
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Multi-tenant enabled deployment. Onboard tenants - offboard tenants - re-onboard 2 tenants |Fast 2020 - Release Test-Ready|Provider deployment was successful, tenants were correctly onboarded. Viya4 deployment stabilized and was accessible. Offboard and re-onboard of 2 tenants was successful.|
|2|Multi-tenant enabled deployment.  Onboard tenants - offboard tenants |Stable 2022.12| In progress|