### PR TITLE
feat: (IAC-849) Updates for Kustomize 4.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kustomize_version=3.7.0
+ARG kustomize_version=4.5.7
 ARG kubectl_version=1.23.8
 
 WORKDIR /build

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~ | docker | >=20.10.10 |
 | ~ | git | any |
 | ~ | rsync | any |
-| ~ | kustomize | 4.5.7 for SAS Viya Platform cadence versions <= 2023.01 <br><br> 3.7.0 for SAS Viya Platform cadence versions >= 2023.02 |
+| ~ | kustomize | 4.5.7 for SAS Viya Platform cadence versions >= 2023.02 <br><br> 3.7.0 for SAS Viya Platform cadence versions <= 2023.01 |
 | ~ | kubectl | 1.22 - 1.24 |
 | ~ | Helm | 3 |
 | pip3 | ansible | 2.10.7 |

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~ | docker | >=20.10.10 |
 | ~ | git | any |
 | ~ | rsync | any |
-| ~ | kustomize | 3.7.0 |
+| ~ | kustomize | 4.5.7 |
 | ~ | kubectl | 1.22 - 1.24 |
 | ~ | Helm | 3 |
 | pip3 | ansible | 2.10.7 |

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~ | docker | >=20.10.10 |
 | ~ | git | any |
 | ~ | rsync | any |
-| ~ | kustomize | 4.5.7 |
+| ~ | kustomize | 4.5.7 for SAS Viya Platform cadence versions <= 2023.01 <br><br> 3.7.0 for SAS Viya Platform cadence versions >= 2023.02 |
 | ~ | kubectl | 1.22 - 1.24 |
 | ~ | Helm | 3 |
 | pip3 | ansible | 2.10.7 |
@@ -42,6 +42,12 @@ If deploying via the [Dockerfile](../../Dockerfile) overriding a dependency vers
 As described in the [Docker Installation](./DockerUsage.md) section add additional build arguments to your docker build command:
 
 ```bash
+# Override kustomize version
+docker build \
+	--build-arg kustomize_version=3.7.0 \
+	-t viya4-deployment .
+	
+# Override kubectl version
 docker build \
 	--build-arg kubectl_version=1.23.8 \
 	-t viya4-deployment .

--- a/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
@@ -52,16 +52,38 @@
   tags:
     - offboard
 
+- name: kustomize - check version
+  command:
+    cmd: kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
+  register: kustomize_version
+  tags:
+    - onboard
+    - offboard
+
 # Build the manifest file
 - name: kustomize - generate onboard manifest
-  ansible.builtin.shell: |
-    kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
+  block:
+    - name: kustomize - generate onboard manifest
+      ansible.builtin.shell: |
+        kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
+      when: kustomize_version|float >= 4.0.1
+    - name: kustomize - generate onboard manifest - legacy flags
+      ansible.builtin.shell: |
+        kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
+      when: kustomize_version|float < 4.0.1
   tags:
     - onboard
 
 - name: kustomize - generate offboard manifest
-  ansible.builtin.shell: |
-    kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
+  block:
+    - name: kustomize - generate offboard manifest
+      ansible.builtin.shell: |
+        kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
+      when: kustomize_version|float >= 4.0.1
+    - name: kustomize - generate offboard manifest - legacy flags
+      ansible.builtin.shell: |
+        kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
+      when: kustomize_version|float < 4.0.1
   tags:
     - offboard
 

--- a/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
@@ -53,8 +53,8 @@
     - offboard
 
 - name: kustomize - check version
-  command:
-    cmd: kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
+  ansible.builtin.shell: |
+    kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
   register: kustomize_version
   tags:
     - onboard
@@ -66,11 +66,11 @@
     - name: kustomize - generate onboard manifest
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
-      when: kustomize_version|float >= 4.0.1
+      when: kustomize_version.stdout is version("4.0.1", '>=')
     - name: kustomize - generate onboard manifest - legacy flags
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
-      when: kustomize_version|float < 4.0.1
+      when: kustomize_version.stdout is version("4.0.1", '<')
   tags:
     - onboard
 
@@ -79,11 +79,11 @@
     - name: kustomize - generate offboard manifest
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
-      when: kustomize_version|float >= 4.0.1
+      when: kustomize_version.stdout is version('4.0.1', '>=')
     - name: kustomize - generate offboard manifest - legacy flags
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
-      when: kustomize_version|float < 4.0.1
+      when: kustomize_version.stdout is version('4.0.1', '<')
   tags:
     - offboard
 

--- a/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-onboard-offboard.yaml
@@ -52,25 +52,19 @@
   tags:
     - offboard
 
-- name: kustomize - check version
-  ansible.builtin.shell: |
-    kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
-  register: kustomize_version
-  tags:
-    - onboard
-    - offboard
-
 # Build the manifest file
 - name: kustomize - generate onboard manifest
   block:
     - name: kustomize - generate onboard manifest
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
-      when: kustomize_version.stdout is version("4.0.1", '>=')
+      when: V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
     - name: kustomize - generate onboard manifest - legacy flags
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-onboard.yaml
-      when: kustomize_version.stdout is version("4.0.1", '<')
+      when:
+        - V4_CFG_CADENCE_VERSION is version('2023.01', "<=")
+        - V4_CFG_CADENCE_NAME|lower != "fast"
   tags:
     - onboard
 
@@ -79,11 +73,13 @@
     - name: kustomize - generate offboard manifest
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load-restrictor LoadRestrictionsNone -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
-      when: kustomize_version.stdout is version('4.0.1', '>=')
+      when: V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
     - name: kustomize - generate offboard manifest - legacy flags
       ansible.builtin.shell: |
         kustomize build {{ DEPLOY_DIR }}/site-config/sas-tenant-job/ --load_restrictor='none' -o {{ DEPLOY_DIR }}/site-config/sas-tenant-job/site-offboard.yaml
-      when: kustomize_version.stdout is version('4.0.1', '<')
+      when:
+        - V4_CFG_CADENCE_VERSION is version('2023.01', "<=")
+        - V4_CFG_CADENCE_NAME|lower != "fast"
   tags:
     - offboard
 

--- a/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
+++ b/roles/multi-tenancy/tasks/multi-tenant-setup.yaml
@@ -31,6 +31,21 @@
     - onboard
     - offboard
 
+# Update the job names to unique identifier - required for Kustomize v4.5.7+
+- name: sas-tenant-job - update job-name
+  replace:
+    path: "{{ item.path }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { path: '{{ DEPLOY_DIR }}/site-config/sas-tenant-job/tenant-onboard-job.yaml', regexp: '{% raw %}{{ JOB-TAG }}{% endraw %}', replace: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}" }
+    - { path: '{{ DEPLOY_DIR }}/site-config/sas-tenant-job/tenant-offboard-job.yaml', regexp: '{% raw %}{{ JOB-TAG }}{% endraw %}', replace: "{{ lookup('password', '/dev/null chars=ascii_letters,digit length=8') | lower }}" }
+  when: 
+    - V4MT_ENABLE
+    - V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+  tags:
+    - onboard
+    - offboard
 
 - name: sas-tenant-job - update sas-tenant-ids
   replace:

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Run Validations
+  include_tasks: validations.yaml
+  tags:
+    - install
+    - uninstall
+    - update
+    - multi-tenancy
+
 - file:
     state: directory
     dest: '{{ DEPLOY_DIR }}/site-config/'

--- a/roles/vdm/tasks/validations.yaml
+++ b/roles/vdm/tasks/validations.yaml
@@ -1,11 +1,11 @@
 ---
 - name: kustomize validation
   block:
-    - name: kustomize - check version
+    - name: validations - kustomize get version
       ansible.builtin.shell: |
         kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
       register: kustomize_version
-    - name: kustomize - check version >= 2023.02
+    - name: validations - kustomize check version >= 2023.02
       ansible.builtin.assert:
         that: '{{ kustomize_version.stdout is version("4.5.7", "==") }}'
         msg: >
@@ -17,7 +17,7 @@
           
           If you are running viya4-deployment directly on your host please install the correct kustomize binary
       when: V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
-    - name: kustomize - check version <= 2023.01
+    - name: validations - kustomize check version <= 2023.01
       ansible.builtin.assert:
         that: '{{ kustomize_version.stdout is version("3.7.0", "==") }}'
         msg: >

--- a/roles/vdm/tasks/validations.yaml
+++ b/roles/vdm/tasks/validations.yaml
@@ -1,0 +1,41 @@
+---
+- name: kustomize validation
+  block:
+    - name: kustomize - check version
+      ansible.builtin.shell: |
+        kustomize version --short | awk -F "/v" '{print $2}' | awk '{print $1}'
+      register: kustomize_version
+    - name: kustomize - check version >= 2023.02
+      ansible.builtin.assert:
+        that: '{{ kustomize_version.stdout is version("4.5.7", "==") }}'
+        msg: >
+          When deploying the SAS Viya Platform on cadence versions >= 2023.02 you must have
+          kustomize version 4.5.7 installed.
+          
+          If you are executing viya4-deployment using a docker container, see docs/user/Dependencies.md#docker on how to
+          override the installed kustomize version during the image build process.
+          
+          If you are running viya4-deployment directly on your host please install the correct kustomize binary
+      when: V4_CFG_CADENCE_VERSION is version('2023.02', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - name: kustomize - check version <= 2023.01
+      ansible.builtin.assert:
+        that: '{{ kustomize_version.stdout is version("3.7.0", "==") }}'
+        msg: >
+          When deploying the SAS Viya Platform on cadence versions >= 2023.01 you must have
+          kustomize version 3.7.0 installed.
+          
+          If you are executing viya4-deployment using a docker container, see docs/user/Dependencies.md#docker on how to
+          override the installed kustomize version during the image build process.
+          
+          If you are running viya4-deployment directly on your host please install the correct kustomize binary
+      when:
+        - V4_CFG_CADENCE_VERSION is version('2023.01', "<=")
+        - V4_CFG_CADENCE_NAME|lower != "fast"
+  # Only two instances in the code where we use the installed kustomize binary
+  when:
+    - V4MT_ENABLE or V4_DEPLOYMENT_OPERATOR_ENABLED
+  tags:
+    - install
+    - uninstall
+    - update
+    - multi-tenancy


### PR DESCRIPTION
### Changes

* Updated the default version of kustomize in the Dockerfile to 4.5.7 since 2023.02 will now requires that
* Conditional statements added to switch between 3.7.0 & 4.5.7 versions of the command depending on the SAS cadence you will be deployinh
* Added kustomize version validation based om cadence.

### Tests


Validated that the correct flag was used per kustomize command depending on version, and ensured a warning was thrown if the wrong version was present.

The default version of kustomize in the dockerfile is now 4.5.7 and the user can still override the version when building the image using the flag `--build-arg kustomize_version=3.7.0` in conjunction with docker build (This is existing documented behavior.)

| Scenario | Task                                | V4_DEPLOYMENT_OPERATOR_ENABLED | Provider | K8s Version        | Deployment Method | Kustomize Version | Cadence          | Notes                                                      |
|----------|-------------------------------------|--------------------------------|----------|--------------------|-------------------|-------------------|------------------|------------------------------------------------------------|
| 1        | OOTB MT /w DO                       | TRUE                           | Azure    | v1.23.8            | Docker            | 4.5.7             | fast:2020 - R/TR | correct flag used in kustomize command for on/offboarding  |
| 2        | OOTB MT /w DO                       | TRUE                           | GCP      | v1.23.14-gke.401   | Docker            | 3.7.0             | 2023.01 - R/P    | correct flag used in kustomize command for on/offboarding  |
| 3        | OOTB MT /w DO - Incorrect kustomize | TRUE                           | Azure    | v1.23.8            | Docker            | 3.7.0             | fast:2020 - R/TR | warning thrown                                             |
| 4        | OOTB MT /w DO - Incorrect kustomize | TRUE                           | GCP      | v1.23.14-gke.401   | Docker            | 4.5.7             | 2023.01 - R/P    | warning thrown                                             |
| 5        | OOTB with Deploy Command            | FALSE                          | Azure    | v1.21.14-gke.14600 | Docker            | 3.7.0             | fast:2020 - R/TR | warning not thrown since local kustomize is not being used |


Internal ticket will include additional details.