### PR TITLE
feat: (IAC-878) support external cds postgres

### DIFF
--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -145,6 +145,15 @@
 
 - name: postgres instance - external post 2022.10
   block:
+  - name: postgres instance - external cds resource
+    overlay_facts:
+      cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+      cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+      existing: "{{ vdm_overlays }}"
+      add:
+        - { resources: "overlays/postgres/cds-postgres", min: "2022.12" }
+    when: 
+      - role == "cds-postgres"
   - name: postgres instance - external copy postgres-user.env
     template:
       src: "postgres-user.env"
@@ -170,7 +179,7 @@
         - { generators: "postgres-{{ role }}-secrets.yaml", min: "2022.10", vdm: true}
   when:
     - not settings.internal
-    - role == "default"
+    - role == "default" or role == "cds-postgres"
     - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
   tags:
     - install
@@ -194,6 +203,7 @@
   when:
     - not settings.internal
     - role != "default"
+    - role != "cds-postgres"
     - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
   tags:
     - install

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -143,7 +143,7 @@
     - uninstall
     - update
 
-- name: postgres instance - external post 2022.10 - external cds 2022.12
+- name: postgres instance - external cds post 2022.12
   block:
   - name: postgres instance - external cds resource
     overlay_facts:

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -143,7 +143,7 @@
     - uninstall
     - update
 
-- name: postgres instance - external post 2022.10
+- name: postgres instance - external post 2022.10 - external cds 2022.12
   block:
   - name: postgres instance - external cds resource
     overlay_facts:

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -143,7 +143,7 @@
     - uninstall
     - update
 
-- name: postgres instance - external cds post 2022.12
+- name: postgres instance - external post 2022.10 - external cds post 2022.12
   block:
   - name: postgres instance - external cds resource
     overlay_facts:

--- a/roles/vdm/tasks/postgres/postgres.yaml
+++ b/roles/vdm/tasks/postgres/postgres.yaml
@@ -9,7 +9,8 @@
   ansible.builtin.fail:
     msg: "CDS postgres instance must be internal server. To use CDS postgres, please reconfigure your infrastructure to set all your postgres servers internal"
   when:
-    - V4_CFG_CADENCE_VERSION is version('2022.10', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_CADENCE_VERSION is version('2022.11', "<=") 
+    - V4_CFG_CADENCE_NAME|lower != "fast"
     - V4_CFG_POSTGRES_SERVERS['cds-postgres'] is defined
     - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal is defined
     - V4_CFG_POSTGRES_SERVERS['cds-postgres'].internal == false

--- a/roles/vdm/templates/transformers/dataserver-transformer.yaml
+++ b/roles/vdm/templates/transformers/dataserver-transformer.yaml
@@ -1,8 +1,9 @@
 {%- set db = db_default_name_map[role] if ('database' not in settings and role in db_default_name_map) else settings.database|default(role, true) -%}
+{%- set dataserver_name = pg_dataserver_name_map[role] -%}
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
-  name: sas-platform-postgres-dataserver-transformer
+  name: {{ dataserver_name }}-dataserver-transformer
 patch: |-
   - op: replace
     path: /spec/databases/0/name
@@ -31,4 +32,4 @@ target:
   group: webinfdsvr.sas.com
   kind: DataServer
   version: v1beta1
-  name: sas-platform-postgres
+  name: {{ dataserver_name }}

--- a/roles/vdm/vars/main.yaml
+++ b/roles/vdm/vars/main.yaml
@@ -3,7 +3,13 @@ PROXY_SQL_IMAGE: gcr.io/cloudsql-docker/gce-proxy:1.20.2
 vdm_overlays: {}
 
 db_default_name_map: {
-  default: "SharedServices"
+  default: "SharedServices",
+  cds-postgres: "SharedServices"
+}
+
+pg_dataserver_name_map: {
+  default: "sas-platform-postgres",
+  cds-postgres: "sas-cds-postgres"
 }
 
 pg_cluster_name_map: {


### PR DESCRIPTION
### Changes
Along with the Crunchy 5 changes made in 2022.10, a blanket support statement was made that CDS Postgres should be internal only. Other teams now want to use CDS externally so allow DAC to configure and deployments to use external default and cds-postgres PostgreSQL instances for 2022.12 cadence and later.

- Change message boundary to pre 2022.12 cadences for cds-postgres instance must be internal only
- Generate user.env, secrets generator and dataserver-transformer for an external cds-postgres instance
- Modify dataserver-transformer template so that it can generate sas-platform-postgres-dataserver-transformer and sas-cds-postgres-dataserver-transformer outputs with expected dataserver names
- Include cds-postgres overlay for an external cds-postgres instance
- Use SharedServices as default cds-postgres database name when no setting is provided


### Tests
See internal ticket for additional details.

| Scenario | Task |Provider |K8s| V4_DEPLOYMENT_OPERATOR_ENABLED | Deployment Method | Viya TLS| Cadence | Notes |
|---------|--------------|----------|----------|----------|---------------|----|--------|----------------|
| 2    | External cds-postgres pre 2022.12 |Azure | v1.23.14 | false  | Ansible | full-stack | 2022.11    | As expected DAC displays the following message and exits: "CDS postgres instance must be internal server. To use CDS postgres, please reconfigure your infrastructure to set all your postgres servers internal"  |
| 3    |External cds-postgres 2022.12 |Azure | v1.23.14 | false  | Ansible | full-stack|2022.12    | As expected deployment is allowed, both default-dataserver-transformer, cds-postgres-dataserver-transformer are generated with expected content.  |
|4| fast:2020 VA-VDMML default & cds-postgres external | AWS|1.23.14 |false |Ansible|full-stack|fast:2020|Deployment stabilized with all pods Running, configured the same custom db name in ansible-vars for each PG server|
|5| risk-cirrus, TLS disabled |AWS|1.23.14|false|Ansible|disabled|stable:2023.01|All sas-risk-cirrus pods stabilized and running. Verified sas-risk-data pod successful connection to external cds-postgres instance and SCHEMA creation.|
|7|risk-cirrus, TLS enabled |AWS|1.23.14|false|Ansible|front-door|stable:2023.01|Deployment stabilized, all sas-risk-cirrus-pods running. sas-risk-data pod log shows successful connection to ssl_enabled external cds-postgres instance and SCHEMA creation.|
|8| risk-cirrus, TLS enabled |Azure|1.24.6|false|Ansible| front-door|stable:2023.01| sas-risk-data pod log shows successful connection to external cds-postgres instance and SCHEMA creation. Deployment stabilized with all risk-cirrus pods Running. |
|9|risk-cirrus, Deployment Operator, TLS enabled |Azure|1.24.6|true|Ansible| front-door|stable:2023.01| DO enabled. Deployment stabilized, all sas-risk-cirrus-pods Running. sas-risk-data pod log showing successful connection to ssl_enabled external cds-postgres instance and SCHEMA creation.|
