### PR TITLE
docs: (IAC-894) Add troubleshoot documentation around docker requirements.

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -45,7 +45,7 @@ When using sassoftware/viya4-deployment releases 5.0.0 or later, specify either 
 
 ## SAS Viya Orchestration Tool
 ### Symptom:
-While deploying the SAS Viya platform to a cluster by running the viya4-deployment project directly on your host with the "viya" and "install" Ansible task tags specified (see [AnsibleUsage.md](./docs/user/AnsibleUsage.md)), the following error message is encountered when the "vdm - orchestration" task executes:
+While deploying the SAS Viya platform to a cluster by running the viya4-deployment project directly on your host with the "viya" and "install" Ansible task tags specified (see [AnsibleUsage.md](./user/AnsibleUsage.md)), the following error message is encountered when the "vdm - orchestration" task executes:
 
 ```bash
 TASK [vdm : orchestration - log into V4_CFG_CR_HOST] ******************************************************************************************************************************************************
@@ -60,7 +60,7 @@ The orchestration task attempted to log into the container registry defined `V4_
 As of [release 6.0.0](https://github.com/sassoftware/viya4-deployment/releases/tag/6.0.0), it's required that if you are running this project using Ansible directly on your workstation, it needs Docker to be installed and the executing user should be able to access it. This is so that we can consume the [sas-orchestration tool](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p1garxk7w4avg2n1hd6e4nt5kks7), which is available as a Docker image to generate the [SASDeployment Custom Resource file](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p012wq5dhcqbx8n12abyqe25m4nu)
 
 On your host:
-* Ensure that Docker is installed on your machine, the [Dependency Versions documentation](./docs/user/Dependencies.md) states that you need at least version 20.10.10.
+* Ensure that Docker is installed on your machine, the [Dependency Versions documentation](./user/Dependencies.md) states that you need at least version 20.10.10.
 * If Docker is already installed on you machine ensure that the deamon is running, see [offical Docker documentation](https://docs.docker.com/config/daemon/start/).
 
 ## SAS Viya Deployment Operator

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -44,6 +44,7 @@ Release 5.0.0 (and later) of sassoftware/viya4-deployment is only compatible wit
 When using sassoftware/viya4-deployment releases 5.0.0 or later, specify either the stable branch or a valid sassoftware/viya4-monitoring-kubernetes release tag of 1.2.0 or later for the value of the V4M_VERSION sassoftware/viya4-deployment variable, For more details on supported variables, refer to [CONFIG-VARS.md](./CONFIG-VARS.md)
 
 ## SAS Viya Orchestration Tool
+
 ### Symptom:
 While deploying the SAS Viya platform to a cluster by running the viya4-deployment project directly on your host with the "viya" and "install" Ansible task tags specified (see [AnsibleUsage.md](./user/AnsibleUsage.md)), the following error message is encountered when the "vdm - orchestration" task executes:
 
@@ -53,7 +54,7 @@ fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error connecting: Erro
 ```
 
 ### Diagnosis:
-The orchestration task attempted to log into the container registry defined `V4_CFG_CR_URL` using the Python Docker client and failed to do so since it could not communicate with the local Docker Engine API.
+The orchestration task attempted to log into the container registry defined by `V4_CFG_CR_URL` using the Python Docker client and failed to do so since it could not communicate with the local Docker Engine API.
 
 ### Solution:
 
@@ -61,7 +62,7 @@ As of [release 6.0.0](https://github.com/sassoftware/viya4-deployment/releases/t
 
 On your host:
 * Ensure that Docker is installed on your machine, the [Dependency Versions documentation](./user/Dependencies.md) states that you need at least version 20.10.10.
-* If Docker is already installed on you machine ensure that the deamon is running, see [offical Docker documentation](https://docs.docker.com/config/daemon/start/).
+* If Docker is already installed on you machine ensure that the deamon is running, see the [offical Docker documentation](https://docs.docker.com/config/daemon/start/).
 
 ## SAS Viya Deployment Operator
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -43,6 +43,26 @@ Release 5.0.0 (and later) of sassoftware/viya4-deployment is only compatible wit
 ### Solution:
 When using sassoftware/viya4-deployment releases 5.0.0 or later, specify either the stable branch or a valid sassoftware/viya4-monitoring-kubernetes release tag of 1.2.0 or later for the value of the V4M_VERSION sassoftware/viya4-deployment variable, For more details on supported variables, refer to [CONFIG-VARS.md](./CONFIG-VARS.md)
 
+## SAS Viya Orchestration Tool
+### Symptom:
+While deploying the SAS Viya platform to a cluster by running the viya4-deployment project directly on your host with the "viya" and "install" Ansible task tags specified (see [AnsibleUsage.md](./docs/user/AnsibleUsage.md)), the following error message is encountered when the "vdm - orchestration" task executes:
+
+```bash
+TASK [vdm : orchestration - log into V4_CFG_CR_HOST] ******************************************************************************************************************************************************
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error connecting: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))"}
+```
+
+### Diagnosis:
+The orchestration task attempted to log into the container registry defined `V4_CFG_CR_URL` using the Python Docker client and failed to do so since it could not communicate with the local Docker Engine API.
+
+### Solution:
+
+As of [release 6.0.0](https://github.com/sassoftware/viya4-deployment/releases/tag/6.0.0), it's required that if you are running this project using Ansible directly on your workstation, it needs Docker to be installed and the executing user should be able to access it. This is so that we can consume the [sas-orchestration tool](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p1garxk7w4avg2n1hd6e4nt5kks7), which is available as a Docker image to generate the [SASDeployment Custom Resource file](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p012wq5dhcqbx8n12abyqe25m4nu)
+
+On your host:
+* Ensure that Docker is installed on your machine, the [Dependency Versions documentation](./docs/user/Dependencies.md) states that you need at least version 20.10.10.
+* If Docker is already installed on you machine ensure that the deamon is running, see [offical Docker documentation](https://docs.docker.com/config/daemon/start/).
+
 ## SAS Viya Deployment Operator
 
 ### Symptom:

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -62,7 +62,7 @@ As of [release 6.0.0](https://github.com/sassoftware/viya4-deployment/releases/t
 
 On your host:
 * Ensure that Docker is installed on your machine, the [Dependency Versions documentation](./user/Dependencies.md) states that you need at least version 20.10.10.
-* If Docker is already installed on you machine ensure that the deamon is running, see the [offical Docker documentation](https://docs.docker.com/config/daemon/start/).
+* If Docker is already installed on you machine ensure that the deamon is running, see the [Docker documentation](https://docs.docker.com/config/daemon/start/).
 
 ## SAS Viya Deployment Operator
 


### PR DESCRIPTION
### Changes
Adds troubleshooting documentation around Docker requirements when you are running this project directly on your host rather than using the docker container.

As of [release 6.0.0](https://github.com/sassoftware/viya4-deployment/releases/tag/6.0.0), it's required that if you are running this project using Ansible directly on your workstation, it needs Docker to be installed and the executing user should be able to access it. This is so that we can consume the [sas-orchestration tool](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p1garxk7w4avg2n1hd6e4nt5kks7), which is available as a Docker image to generate the [SASDeployment Custom Resource file](https://go.documentation.sas.com/doc/en/itopscdc/default/dplyml0phy0dkr/p0nid9gu3x2cvln1pzpcxa68tpom.htm#p012wq5dhcqbx8n12abyqe25m4nu)

So this extra doc will help users who run into a failures around this missing dep.