### PR TITLE
feat: (IAC-874) Update default cert-manager version to 1.11.0

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -345,7 +345,7 @@ Notes:
 | CERT_MANAGER_NAMESPACE | cert-manager Helm installation namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager Helm chart URL | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager Helm chart name | string | cert-manager| false | | baseline |
-| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.9.1 | false | | baseline |
+| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.11.0 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 
 Notes:

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -8,7 +8,7 @@ CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
-CERT_MANAGER_CHART_VERSION: 1.9.1
+CERT_MANAGER_CHART_VERSION: 1.11.0
 CERT_MANAGER_CONFIG: 
   installCRDs: "true"
   extraArgs:


### PR DESCRIPTION
### Changes

Updated the default cert-manager version (`CERT_MANAGER_CHART_VERSION`) to 1.11.0

This new version is compatible with K8s 1.21 → 1.26, this version should work with all supported Viya cadences that are able to deployed on that K8s version range.

### Tests

Ran through the following scenarios to test the updated cert-manager version

| Scenario | Task                      | Provider | Cadence        | K8s Version          | V4_CFG_TLS_GENERATOR | V4_CFG_TLS_MODE | V4_CFG_TLS_CERT/KEY/TRUSTED_CA_CERTS | Deployment Method |
|----------|---------------------------|----------|----------------|----------------------|----------------------|-----------------|--------------------------------------|-------------------|
| 1        | OOTB + Logging Monitoring | Azure    | fast:2020      | v1.24.9              | cert-manager         | full-stack      | User Provided                        | Docker            |
| 2        | OOTB + Logging Monitoring | Azure    | fast:2020      | v1.24.9              | cert-manager         | full-stack      | Generated                            | Docker            |
| 3        | OOTB + Logging Monitoring | AWS      | lts:2022.09    | v1.23.15-eks-300e41d | cert-manager         | front-door      | User Provided                        | Docker            |
| 4        | OOTB + Logging Monitoring | AWS      | lts:2022.09    | v1.23.15-eks-300e41d | cert-manager         | front-door      | Generated                            | Docker            |
| 5        | OOTB + Logging Monitoring | GCP      | lts:2022.09    | v1.23.14-gke.401     | cert-manager         | full-stack      | Generated                            | Docker            |
| 6        | OOTB + Logging Monitoring | vsphere  | stable:2023.01 | v1.22.17             | cert-manager         | front-door      | User Provided                        | Docker            |

See internal ticket for more details.