### PR TITLE
fix: (IAC-536): fixed rabbitmq pods failed after adding a new node pool

### DIFF
--- a/roles/vdm/templates/transformers/rabbitmq-pod-security.yaml
+++ b/roles/vdm/templates/transformers/rabbitmq-pod-security.yaml
@@ -1,4 +1,4 @@
-# This patch transformer resolves the 'sas-rabbitmq-server' pod failures on Kubernetes with the error, below - when adding or removing StatefulSet nodes on AWS EKS.
+# This patch transformer resolves the 'sas-rabbitmq-server' pod failures on Kubernetes with the error, below - when adding or removing AWS 'connect' node pool.
  
  # " [error] Cookie file /rabbitmq/data/.erlang.cookie must be accessible by owner only " 
 
@@ -8,7 +8,7 @@
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
-  name: rabbitmq-node-security
+  name: rabbitmq-pod-security
 patch: |-
   - op: replace
     path: /spec/template/spec/containers/0/securityContext


### PR DESCRIPTION
## Changes
The `rabbitmq-pod-security` patch transformer resolves the 'sas-rabbitmq-server' pod failures on Kubernetes with the error "`[error] Cookie file /rabbitmq/data/.erlang.cookie must be accessible by owner only`" - when adding or removing the 'connect' node pool on AWS EKS.

This 'PatchTransformer' modifies the pod's 'securityContext' configuration of the 'sas-rabbitmq-server' container, which resolves the file permission issue that leads to the error message. Specifically, by setting the 'runAsUser' attribute to 1001, the container runs as a non-root user, which ensures that the '.erlang.cookie' file is accessible only by the owner.

Additionally, the patch disables privilege escalation and sets the container to run in read-only mode, further enhancing the security of the container. Overall, these modifications should ensure that the 'sas-rabbitmq-server' pods run correctly without any issues related to the '.erlang.cookie' file permissions.

## Testing
See internal ticket for details and test artifacts:

|Scenario|Deployment Method|Security|Orchestration|Provider:Terraform:K8s|Cadence|PatchTransformer|Node Added|Node Removed|Results|
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
|1|ansible|full-stack:openssl|DO|AWS:workstation:v1.22|fast:2020|none|Connect|Connect|Failed (expected)|
|2|ansible|full-stack:openssl|DO|AWS:workstation:v1.23|fast:2020|none|Connect|Connect|Failed (expected)|
|3|ansible|full-stack:openssl|DO|AWS:workstation:v1.24|fast:2020|none|Connect|Connect|Failed (expected)|
|4|ansible|full-stack:openssl|DO|AWS:workstation:v1.25|fast:2020|none|Connect|Connect|Failed (expected)|
|5|ansible|full-stack:openssl|DO|AWS:workstation:v1.22|stable:2023.02|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|6|ansible|full-stack:openssl|DO|AWS:workstation:v1.23|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|7|ansible|full-stack:openssl|DO|AWS:workstation:v1.24|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|8|ansible|full-stack:openssl|DO|AWS:workstation:v1.25|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|9|docker|full-stack:openssl|DO|AWS:docker-5.5.0:v1.22|stable:2023.02|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|10|docker|full-stack:openssl|DO|AWS:docker-5.5.0:v1.23|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|11|docker|full-stack:openssl|DO|AWS:docker-5.5.0:v1.24|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|
|12|docker|full-stack:openssl|DO|AWS:docker-5.5.0:v1.25|fast:2020|rabbitmq-pod-security.yaml|Connect|Connect|Successful|