### PR TITLE
fix: (IAC-909) storageClasses not created during baseline install w/out V4_CFG_MANAGE_STORAGE explicitly defined

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -2,6 +2,7 @@ V4_CFG_TLS_MODE: "full-stack" # other valid values are front-door, ingress-only,
 V4_CFG_RWX_FILESTORE_PATH: /export
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_MODE: public
+V4_CFG_MANAGE_STORAGE: true
 
 ## Cert-manager
 CERT_MANAGER_NAME: cert-manager


### PR DESCRIPTION
### Changes
The update made to the default value for V4_CFG_MANAGE_STORAGE in #334 impacted the viya based install tasks. The default for that variable should have also been added to the baseline defaults so that the baseline tasks will behave as if V4_CFG_MANAGE_STORAGE=true if it is not specified as a configuration variable in ansible-vars or with command line flags. Adding the default value of V4_CFG_MANAGE_STORAGE=true as a baseline default value allows for the creation of the "sas" and "pg-storage" storage classes during the "baseline,install" task as the default behavior as intended with #334.
### Tests

Behavior prior to this update
| Scenario | DAC version | Method | V4_CFG_MANAGE_STORAGE | DAC tags| storage class install,uninstall results | Expected result |
|-|-|-|-|-|-|-|
| 1 | 6.2.0-staging image | docker | not present | "baseline,install" |  nfs-subdir-external-provisioner.yaml task is skipped during baseline install, "sas" and "pg-storage" storageClasses are not created | storage classes should be created
| 2 | current staging branch | ansible | not present | "baseline,install" |  nfs-subdir-external-provisioner.yaml task is skipped during baseline install, "sas" and "pg-storage" storageClasses are not created| storage classes should be created
| 3 | current staging branch | ansible | set to true in ansible-vars | "baseline,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created in nfs-client namespace | storage classes should be created
| 4 | current staging branch | ansible | set via -e V4_CFG_MANAGE_STORAGE=true on command line  | "baseline,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created in nfs-client namespace | storage classes should be created
| 5 | current staging branch | ansible | not present | "baseline,uninstall" |  nfs-subdir-external-provisioner.yaml task is skipped during baseline install, "sas" and "pg-storage" storageClasses are not uninstalled | storage classes should be uninstalled
| 6 | current staging branch | ansible | set to true in ansible-vars | "baseline,uninstall" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully uninstalled |storage classes should be uninstalled

Behavior after update
| Scenario | DAC version | Method | V4_CFG_MANAGE_STORAGE | DAC tags| storage class install,uninstall results | Expected result |
|-|-|-|-|-|-|-|
| 7 | iac-909 branch dd869fe  | ansible | not present | "baseline,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created | storage classes should be created
| 8 | iac-909 branch dd869fe | ansible | not present | "baseline,uninstall" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully uninstalled | storage classes should be uninstalled
| 9 | iac-909 branch dd869fe  | ansible | set to true in ansible-vars| "baseline,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created |storage classes should be created
| 10 | iac-909 branch dd869fe  | ansible | set to true in ansible-vars| "baseline,uninstall" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully uninstalled |storage classes should be uninstalled
| 11 | iac-909 branch dd869fe | ansible | set via -e V4_CFG_MANAGE_STORAGE=true on command line  | "baseline,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created in nfs-client namespace | storage classes should be created
| 12 | iac-909 branch dd869fe | ansible | set via -e V4_CFG_MANAGE_STORAGE=true on command line  | "baseline,uninstall" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully uninstalled | storage classes should be uninstalled
| 13 | iac-909 branch dd869fe  | ansible | not present | "baseline,viya,install" |  nfs-subdir-external-provisioner.yaml task executes during baseline install, "sas" and "pg-storage" storageClasses successfully created, viya deployment stabilizes | storage classes should be created, stable viya deployment