### PR TITLE
feat: (IAC-912): Postgres tuning transformer changes for 2023.03 cadence

### DIFF
--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -93,7 +93,7 @@
   loop_control:
     loop_var: file
   when: 
-    - not V4_CFG_CADENCE_NAME|lower == "fast"
+    - not V4_CFG_CADENCE_NAME|lower == "fast" and V4_CFG_CADENCE_VERSION is version('2023.03', "<")
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
@@ -110,7 +110,7 @@
     - { regexp: "#pg_hba:", replace: "pg_hba:" }
     - { regexp: '#  - "hostnossl all all all md5"', replace: ' - "hostnossl all all all md5"' }
   when: 
-    - not V4_CFG_CADENCE_NAME|lower == "fast"
+    - not V4_CFG_CADENCE_NAME|lower == "fast" and V4_CFG_CADENCE_VERSION is version('2023.03', "<")
     - crunchy_tuning_folder.stat.exists
     - settings.internal
     - V4_CFG_TLS_MODE in ["front-door", "disabled"]
@@ -127,7 +127,7 @@
     regexp: '#.*$'
     state: absent
   when: 
-    - not V4_CFG_CADENCE_NAME|lower == "fast"
+    - not V4_CFG_CADENCE_NAME|lower == "fast" and V4_CFG_CADENCE_VERSION is version('2023.03', "<")
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
@@ -147,7 +147,7 @@
     - { regexp: "{% raw %}{{ TRANSFORMER-NAME }}{% endraw %}", replace: "{{ 'platform-postgres' if role == 'default' else role }}" }
     - { regexp: "{% raw %}{{ CLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform-postgres' if role == 'default' else role }}" }
   when: 
-    - not V4_CFG_CADENCE_NAME|lower == "fast"
+    - not V4_CFG_CADENCE_NAME|lower == "fast" and V4_CFG_CADENCE_VERSION is version('2023.03', "<")
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   loop_control:
@@ -165,7 +165,7 @@
     add:
       - { transformers: "{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
   when: 
-    - V4_CFG_CADENCE_VERSION is version('2023.03', "<") or not V4_CFG_CADENCE_NAME|lower == "fast"
+    - not V4_CFG_CADENCE_NAME|lower == "fast" and V4_CFG_CADENCE_VERSION is version('2023.03', "<")
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags: 

--- a/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
+++ b/roles/vdm/tasks/postgres/postgres-multi-tenant-config.yaml
@@ -84,7 +84,7 @@
     - uninstall
     - update
 
-# Updates to support Crunchy v5 internal PostgreSQL
+# Updates to support Crunchy v5 internal PostgreSQL - pre 2023.03
 - name: postgres crunchy v5 - copy custom config 
   copy:
     src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-transformer.yaml"
@@ -93,6 +93,7 @@
   loop_control:
     loop_var: file
   when: 
+    - not V4_CFG_CADENCE_NAME|lower == "fast"
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
@@ -109,6 +110,7 @@
     - { regexp: "#pg_hba:", replace: "pg_hba:" }
     - { regexp: '#  - "hostnossl all all all md5"', replace: ' - "hostnossl all all all md5"' }
   when: 
+    - not V4_CFG_CADENCE_NAME|lower == "fast"
     - crunchy_tuning_folder.stat.exists
     - settings.internal
     - V4_CFG_TLS_MODE in ["front-door", "disabled"]
@@ -125,6 +127,7 @@
     regexp: '#.*$'
     state: absent
   when: 
+    - not V4_CFG_CADENCE_NAME|lower == "fast"
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags:
@@ -144,6 +147,7 @@
     - { regexp: "{% raw %}{{ TRANSFORMER-NAME }}{% endraw %}", replace: "{{ 'platform-postgres' if role == 'default' else role }}" }
     - { regexp: "{% raw %}{{ CLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform-postgres' if role == 'default' else role }}" }
   when: 
+    - not V4_CFG_CADENCE_NAME|lower == "fast"
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   loop_control:
@@ -161,6 +165,134 @@
     add:
       - { transformers: "{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-transformer.yaml", vdm: true, priority: 65 }
   when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', "<") or not V4_CFG_CADENCE_NAME|lower == "fast"
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  tags: 
+    - install
+    - uninstall
+    - update
+
+## Postgres tuning transformer updates for 2023.03 and above
+- name: postgres crunchy v5 - copy custom config transformers
+  copy:
+    src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-connection-params-transformer.yaml"
+    dest: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-connection-params-transformer.yaml"
+    mode: "0660"
+  loop_control:
+    loop_var: file
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - add no-tls transformer for front-door or tls disabled 
+  copy:
+    src: "{{ DEPLOY_DIR }}/sas-bases/examples/crunchydata/tuning/crunchy-tuning-pg-hba-no-tls-transformer.yaml"
+    dest: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-pg-hba-no-tls-transformer.yaml"
+    mode: "0660"
+  loop_control:
+    loop_var: file
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_TLS_MODE in ["front-door", "disabled"]
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - remove commented block
+  lineinfile:
+    path: "{{ outer_item.path }}"
+    regexp: '#.*$'
+    state: absent
+  with_items:
+    - { path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-connection-params-transformer.yaml"}
+    - { path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-pg-hba-no-tls-transformer.yaml"}
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - update max_connections
+  replace:
+    path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-connection-params-transformer.yaml"
+    regexp: "{{ outer_item.regexp }}"
+    replace: "{{ outer_item.replace }}"
+  with_items:
+    - { regexp: "(^\n)", replace: "" }
+    - { regexp: "{% raw %}{{ MAX-CONNECTIONS }}{% endraw %}", replace: "{{ MAX_CONNECTIONS }}" }
+    - { regexp: "{% raw %}{{ MAX-PREPARED-TRANSACTIONS }}{% endraw %}", replace: "{{ MAX_CONNECTIONS }}" }
+    - { regexp: "{% raw %}{{ CLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform-postgres' if role == 'default' else role }}" }
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - update no tls transformer
+  replace:
+    path: "{{ role_path }}/templates/transformers/{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-pg-hba-no-tls-transformer.yaml"
+    regexp: "{{ outer_item.regexp }}"
+    replace: "{{ outer_item.replace }}"
+  with_items:
+    - { regexp: "(^\n)", replace: "" }
+    - { regexp: "{% raw %}{{ CLUSTER-NAME }}{% endraw %}", replace: "sas-crunchy-{{ 'platform-postgres' if role == 'default' else role }}" }
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_TLS_MODE in ["front-door", "disabled"]
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  loop_control:
+    loop_var: outer_item
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - add custom config transformer to kustomization
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: "{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-connection-params-transformer.yaml", vdm: true, priority: 65 }
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - crunchy_tuning_folder.stat.exists
+    - settings.internal
+  tags: 
+    - install
+    - uninstall
+    - update
+
+- name: postgres crunchy v5 - add custom config transformer to kustomization
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: "{{ 'platform-postgres' if role == 'default' else role }}-crunchy-tuning-pg-hba-no-tls-transformer.yaml", vdm: true, priority: 65 }
+  when: 
+    - V4_CFG_CADENCE_VERSION is version('2023.03', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"
+    - V4_CFG_TLS_MODE in ["front-door", "disabled"]
     - crunchy_tuning_folder.stat.exists
     - settings.internal
   tags: 


### PR DESCRIPTION
# Changes:
Postgres has split the tuning transformers `crunchy-tuning-transformer.yaml` which was used for adjusting the max_connections for tenants and enabling/disabling the TLS for front-door TLS on Multi-tenant enabled deployments.
In this change the support for separate transformers has been added for SAS Viya Platform cadence version 2023.03 and above. The new transformers are:
- For adjusting max_connection: `crunchy-tuning-connection-params-transformer.yaml`
- For TLS options front-door/disabled: `crunchy-tuning-pg-hba-no-tls-transformer.yaml`

# Tests:
Verified following scenarios. For details see the internal ticket:
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|TLS: full-stack with schemaPerTenant mode | Fast 2020 |New transformer for connections update was created. Viya4 deployment stabilized and was accessible|
|2|TLS: front-door with schemaPerTenant mode | Fast 2020 |Both the new transformer for connections and TLS update were created. Viya4 deployment stabilized and was accessible|
|3|TLS: disabled with databasePerTenant mode | Fast 2020 |Both the new transformer for connections and TLS update were created. Viya4 deployment stabilized and was accessible|