### PR TITLE
fix: (IAC-917) cluster_logging install fails when V4_CFG_MANAGE_STORAGE is not explicitly defined

### DIFF
--- a/roles/monitoring/defaults/main.yaml
+++ b/roles/monitoring/defaults/main.yaml
@@ -1,5 +1,6 @@
 KUBECONFIG: ~/.kube/config
 NAMESPACE: null
+V4_CFG_MANAGE_STORAGE: true
 
 V4M_STORAGECLASS: v4m
 


### PR DESCRIPTION
### Changes
A default value for V4_CFG_MANAGE_STORAGE is required for viya4-deployment monitoring tasks so DAC will behave as if V4_CFG_MANAGE_STORAGE=true has been set even if it is not specified as a configuration variable in ansible-vars or with command line flags. Adding the default value of V4_CFG_MANAGE_STORAGE=true as a monitoring task default value allows V4M logging and monitoring applications to successfully install/uninstall as expected when V4_CFG_MANAGE_STORAGE=true is not explicitly defined.
### Tests

Behavior prior to this update
| Scenario | DAC version | Method | V4_CFG_MANAGE_STORAGE | DAC tags| monitoring install,uninstall results | Expected result |
|-|-|-|-|-|-|-|
| 1 | DAC 6.2.0 image | docker | not present | "cluster-logging,install" | v4m - add storageclass task fails, DAC exits with this msg:     The conditional check 'V4_CFG_MANAGE_STORAGE' failed. The error was: error while evaluating conditional (V4_CFG_MANAGE_STORAGE): 'V4_CFG_MANAGE_STORAGE' is undefined | cluster-logging should install successfully
| 2 | current DAC staging branch | ansible | not present | "cluster-logging,install" |  v4m - add storageclass task fails, DAC exits with this msg:     The conditional check 'V4_CFG_MANAGE_STORAGE' failed. The error was: error while evaluating conditional (V4_CFG_MANAGE_STORAGE): 'V4_CFG_MANAGE_STORAGE' is undefined | cluster-logging should install successfully
| 3 | current DAC staging branch | ansible | not present | "cluster-monitoring,install" |  v4m - add storageclass task fails, DAC exits with this msg:     The conditional check 'V4_CFG_MANAGE_STORAGE' failed. The error was: error while evaluating conditional (V4_CFG_MANAGE_STORAGE): 'V4_CFG_MANAGE_STORAGE' is undefined | cluster-monitoring should install successfully
| 4 | current DAC staging branch | ansible | not present | "cluster-logging,uninstall" |  v4m - remove storageclass task fails, DAC exits with this msg:     The conditional check 'V4_CFG_MANAGE_STORAGE' failed. The error was: error while evaluating conditional (V4_CFG_MANAGE_STORAGE): 'V4_CFG_MANAGE_STORAGE' is undefined | cluster-logging should uninstall successfully
| 5 | current DAC staging branch | ansible | not present | "cluster-logging,cluster-monitoring,uninstall" |  v4m - remove storageclass task fails, DAC exits with this msg:     The conditional check 'V4_CFG_MANAGE_STORAGE' failed. The error was: error while evaluating conditional (V4_CFG_MANAGE_STORAGE): 'V4_CFG_MANAGE_STORAGE' is undefined | cluster-logging should uninstall successfully

Behavior after update
| Scenario | cadence | V4M_VERSION | DAC version | Method | V4_CFG_MANAGE_STORAGE | DAC tags| monitoring install,uninstall results | Expected result |
|-|-|-|-|-|-|-|-|-|
| 6 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | not present | "cluster-logging,install" | cluster-logging installed successfully | cluster-logging should install successfully
| 7 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | not present | "cluster-logging,uninstall" | cluster-logging uninstalled successfully  | cluster-logging should uninstall succcessfully
| 8 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | set via -e V4_CFG_MANAGE_STORAGE=true on command line  | "cluster-logging,install" |cluster-logging installed successfully | cluster-logging should install successfully 
| 9 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | set to true in ansible-vars| "cluster-logging,install" | cluster-logging installed successfully | cluster-logging should install successfully 
| 10 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | set to true in ansible-vars| "cluster-logging,uninstall" | cluster-logging uninstalled successfully | cluster-logging should uninstall successfully 
| 11 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | set via -e V4_CFG_MANAGE_STORAGE=true on command line  | "cluster-logging,cluster-monitoring,uninstall" | cluster-logging,cluster-monitoring uninstalled successfully | cluster-logging and cluster-monitoring should uninstall successfully 
| 12 | 2023.02 | iac_dac_fix| iac-917 branch | ansible | not present | "baseline,cluster-logging,cluster-monitoring,install" | baseline,cluster-logging,cluster-monitoring installed successfully | baseline, cluster-logging and cluster-monitoring should install successfully 