### PR TITLE
feat: (IAC-892): Upgrade the default ingress-nginx version to work with K8s 1.25

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -385,7 +385,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 is used for Kubernetes clusters whose version is <= 1.21.X, and version 4.2.3 is used for Kubernetes clusters whose version is >= 1.22.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 is used for Kubernetes clusters whose version is <= 1.21.X, and version 4.4.0 is used for Kubernetes clusters whose version is >= 1.22.X. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -385,7 +385,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 is used for Kubernetes clusters whose version is <= 1.21.X, and version 4.4.0 is used for Kubernetes clusters whose version is >= 1.22.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 is used for Kubernetes clusters whose version is <= 1.21.X, and version 4.3.0 is used for Kubernetes clusters whose version is >= 1.22.X. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -34,8 +34,8 @@ ingressVersions:
   k8sMinorVersionFloor:
     value: 22
     api:
-      chartVersion: 4.2.3
-      appVersion: 1.3.0
+      chartVersion: 4.4.0
+      appVersion: 1.4.0
 
 ## Ingress-nginx - Ingress
 INGRESS_NGINX_NAME: ingress-nginx

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -35,7 +35,7 @@ ingressVersions:
   k8sMinorVersionFloor:
     value: 22
     api:
-      chartVersion: 4.4.0
+      chartVersion: 4.3.0
       appVersion: 1.4.0
 
 ## Ingress-nginx - Ingress


### PR DESCRIPTION
# Changes:
In release cadence 2023.03 SAS Viya platform is going to support Kubernetes range of 1.23-1.25. 

Kubernetes v1.25 supports ingress-nginx v1.4.0 or greater. To support the Kubernetes version range from 1.22 to 1.25 we are updating the Helm chart and ingress-nginx versions shown below:
```
  chartVersion: 4.3.0
  appVersion: 1.4.0
```

# Tests:
Verified following scenarios, see details in internal ticket:

|Scenario|Task|Provider|Cadence|kubernetes_version|Actual Kubernetes Cluster Version|Orchestration|Notes|
|:----|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.24|1.24.9|Deployment Operator|SAS Viya platform deployment was successful|
|2|OOTB|Azure|fast:2020|1.25|1.25.5|Deployment Operator|SAS Viya platform deployment was successful|
|3|OOTB|Azure|fast:2020|1.23|1.23.15|Orchestration Tooling|SAS Viya platform deployment was successful|
|4|OOTB|AWS|stable:2023.02|1.22|1.22|Deployment Operator|SAS Viya platform deployment was successful|