### PR TITLE
feat: (IAC-903) Update Cluster Autoscaler for EKS 1.25 Support

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -360,10 +360,15 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | CLUSTER_AUTOSCALER_ENABLED | Whether to deploy cluster-autoscaler | bool | true | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://kubernetes.github.io/autoscaler) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_NAME| Cluster-autoscaler Helm chart name | string | cluster-autoscaler | false | | baseline |
-| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | 9.9.2 | false | | baseline |
+| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.9.2 is used for Kubernetes clusters whose version is <= 1.21 <br> and version 9.25.0 is used for Kubernetes clusters whose version is >= 1.25 | baseline |
 | CLUSTER_AUTOSCALER_CONFIG | Cluster-autoscaler Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_ACCOUNT | Cluster autoscaler AWS role ARN | string | | false | Required to enable cluster-autoscaler on AWS | baseline |
 | CLUSTER_AUTOSCALER_LOCATION |AWS region where Kubernetes cluster is running | string | us-east-1 | false | | baseline |
+
+**Cluster Autoscaler Notes:**
+
+If you used [viya4-iac-aws:5.6.0](https://github.com/sassoftware/viya4-iac-aws/releases) or newer to create your infrastructure, a cluster autoscaler account should have been created for you with a policy that is compatible with both our default versions for the `CLUSTER_AUTOSCALER_CHART_VERSION` variable. If you choose an alternative version ensure that your autoscaler account has a policy that matches the recommendation from the [kubernetes/autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#iam-policy). This note is only applicable for EKS clusters.
+
 
 ### EBS CSI Driver
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -69,4 +69,72 @@ On your host:
 ### Symptom:
 When the SAS Viya Platform Deployment Operator is not working as expected, three different sources can be used to diagnose problems. Follow the commands from the [SAS Viya Platform deployment guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/dplyml0phy0dkr/p127f6y30iimr6n17x2xe9vlt54q.htm#p11o2ghzdkqm6kn1qkxqr2wr3nkh) to check out the SAS Viya Platform Deployment Operator Pod, the SASDeployment Custom Resource, and the Reconcile Job. Remediation steps are also present on that page.
 
+## EKS - Cluster Autoscaler Installation
 
+### Symptom:
+While baselining your 1.25+ EKS cluster using the viya4-deployment project the "Deploy cluster-autoscaler" task failed with a timeout
+
+```bash
+TASK [baseline : Deploy cluster-autoscaler] ************************************
+task path: /viya4-deployment/roles/baseline/tasks/cluster-autoscaler.yaml:15
+fatal: [localhost]: FAILED! => changed=false 
+  command: /usr/local/bin/helm --version=9.25.0 --repo=https://kubernetes.github.io/autoscaler upgrade 
+  -i --reset-values --wait -f=/tmp/tmpzoxsdrsu.yml cluster-autoscaler cluster-autoscaler
+  msg: |-
+    Failure when executing Helm command. Exited 1.
+    stdout: Release "cluster-autoscaler" does not exist. Installing it now.
+  
+    Error: timed out waiting for the condition
+  stderr: |-
+    Error: timed out waiting for the condition
+  stderr_lines: <omitted>
+  stdout: |-
+    Release "cluster-autoscaler" does not exist. Installing it now.
+  stdout_lines: <omitted>
+```
+
+When checking out the `cluster-autoscaler-aws-cluster-autoscaler-xxx-x` in your cluster you see that it's stuck in a CrashLoopBackoff and checking the pods logs you will see the following error (usually near the beginning logs) and a large Stacktrace
+
+```bash
+$ kubectl get pods -n kube-system --selector app.kubernetes.io/instance=cluster-autoscaler
+NAME                                                         READY   STATUS             RESTARTS        AGE
+cluster-autoscaler-aws-cluster-autoscaler-6c496cc6cc-zftxp   0/1     CrashLoopBackOff   7 (4m42s ago)   15m
+$ kubectl logs -n kube-system cluster-autoscaler-aws-cluster-autoscaler-6c496cc6cc-zftxp
+... truncated
+F0227 16:39:34.624005       1 aws_cloud_provider.go:386] Failed to generate AWS EC2 Instance Types: UnauthorizedOperation: You are not authorized to perform this operation.
+        status code: 403, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+... stacktrace truncated
+```
+### Diagnosis:
+
+The "Deploy cluster-autoscaler" task attempted to deploy the 9.25.0 autoscaler helm chart (or newer if you chose to override `CLUSTER_AUTOSCALER_CHART_VERSION`) into your cluster, however the autoscaler deployment failed to start up due to the cluster-autoscaler role having insufficient policies configured.  
+
+As of [release viya4-deployment:6.3.0](https://github.com/sassoftware/viya4-deployment/releases/tag/6.3.0) when installing the cluster-autoscaler on EKS 1.25+ clusters, the [helm chart version 9.25.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-chart-9.25.0) is used for compatibility reasons. This is because Kubernetes 1.25 has deprecated the `PodDisruptionBudget policy/v1beta1` API version in favor of `policy/v1` and this updated cluster-autoscaler version supports that change. This updated cluster-autoscaler chart requires a modified policy for the cluster-autoscaler role to properly function.
+
+Note: As documented in our [CONFIG-VARS.md](./CONFIG-VARS.md), EKS 1.24 and lower clusters will still default to version 9.9.2 of the cluster-autoscaler helm chart.
+
+### Solution:
+
+Note: If you used viya4-iac-aws:5.6.0 or never to create your infrastructure, these steps are not applicable for you. This role & policy should already be correct. 
+
+1. Scale the `cluster-autoscaler-aws-cluster-autoscaler` deployment down to 0
+      ```bash
+      kubectl scale --replicas=0 deployment/cluster-autoscaler-aws-cluster-autoscaler
+      ```
+   Use one of the two options below: 
+   1. If you created your 1.25 EKS infrastructure prior to version 5.6.0 of the [viya4-iac-aws](https://github.com/sassoftware/viya4-iac-aws) project, after pulling the latest release you can run the following to update the cluster-autoscaler policy:
+       ```bash
+       terraform apply -auto-approve \
+         -target=module.autoscaling["0"].aws_iam_policy.worker_autoscaling \
+         -var-file ${PATH_TO_TFVARS} -state ${PATH_TO_TFSTATE}
+       ```
+      See Docker & Terraform usage in the [viya4-iac-aws documentation](https://github.com/sassoftware/viya4-iac-aws/tree/main/docs/user) for additional usage information
+   2. Alternatively, if you have access to the AWS Console and go into the [IAM Roles](https://us-east-1.console.aws.amazon.com/iamv2/home#/roles) page and update the cluster-autoscaler role yourself.
+      * Once you are on the Roles page search for "cluster-autoscaler" and choose the one for your cluster.
+      * Under the "Permissions" tab expand the "eks-worker-autoscaling" policy
+      * Update the `eksWorkerAutoscalingAll` & `eksWorkerAutoscalingOwn` Sids so that it matches the IAM policy as recommend by the [kubernetes/autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md). Make sure to leave the `Condition` block as is.
+        * Switch the repo to the tag of the version of the cluster-autoscaler you are deploying, so that you are viewing the correct documentation.
+2. Scale the `cluster-autoscaler-aws-cluster-autoscaler` deployment back to 1
+      ```bash
+      kubectl scale --replicas=1 deployment/cluster-autoscaler-aws-cluster-autoscaler
+      ```

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,5 +1,11 @@
 # Troubleshooting
 
+* [Debug Mode](#debug-mode)
+* [Viya4 Monitoring and Logging](#viya4-monitoring-and-logging)
+* [SAS Viya Orchestration Tool](#sas-viya-orchestration-tool)
+* [SAS Viya Deployment Operator](#sas-viya-deployment-operator)
+* [EKS - Cluster Autoscaler Installation](#eks---cluster-autoscaler-installation)
+
 ## Debug Mode
 Debug mode can be enabled by adding "-vvv" to the end of the docker or ansible commands
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,10 +1,10 @@
 # Troubleshooting
 
-* [Debug Mode](#debug-mode)
-* [Viya4 Monitoring and Logging](#viya4-monitoring-and-logging)
-* [SAS Viya Orchestration Tool](#sas-viya-orchestration-tool)
-* [SAS Viya Deployment Operator](#sas-viya-deployment-operator)
-* [EKS - Cluster Autoscaler Installation](#eks---cluster-autoscaler-installation)
+- [Troubleshooting](#troubleshooting)
+  - [Viya4 Monitoring and Logging](#viya4-monitoring-and-logging)
+  - [SAS Viya Orchestration Tool](#sas-viya-orchestration-tool)
+  - [SAS Viya Deployment Operator](#sas-viya-deployment-operator)
+  - [EKS - Cluster Autoscaler Installation](#eks---cluster-autoscaler-installation)
 
 ## Debug Mode
 Debug mode can be enabled by adding "-vvv" to the end of the docker or ansible commands

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -135,7 +135,7 @@ CLUSTER_AUTOSCALER_NAME: cluster-autoscaler
 CLUSTER_AUTOSCALER_NAMESPACE: kube-system
 CLUSTER_AUTOSCALER_CHART_NAME: cluster-autoscaler
 CLUSTER_AUTOSCALER_CHART_URL: https://kubernetes.github.io/autoscaler
-CLUSTER_AUTOSCALER_CHART_VERSION: 9.9.2
+CLUSTER_AUTOSCALER_CHART_VERSION: ""
 CLUSTER_AUTOSCALER_ACCOUNT: null
 CLUSTER_AUTOSCALER_LOCATION: us-east-1
 CLUSTER_AUTOSCALER_CONFIG:
@@ -147,6 +147,19 @@ CLUSTER_AUTOSCALER_CONFIG:
       name: cluster-autoscaler
       annotations:
         "eks.amazonaws.com/role-arn": "{{ CLUSTER_AUTOSCALER_ACCOUNT }}"
+
+autoscalerVersions:
+  # Supports PodDisruptionBudget policy/v1beta1 default for K8s <=1.24
+  PDBv1beta1Support:
+    api:
+      chartVersion: 9.9.2
+      appVersion: 1.20.0
+  # Supports PodDisruptionBudget policy/v1beta1 default for K8s >=1.25
+  PDBv1Support:
+    api:
+      chartVersion: 9.25.0
+      appVersion: 1.24.0
+
 
 ## EBS CSI Driver
 EBS_CSI_DRIVER_ENABLED: true

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -160,7 +160,6 @@ autoscalerVersions:
       chartVersion: 9.25.0
       appVersion: 1.24.0
 
-
 ## EBS CSI Driver
 EBS_CSI_DRIVER_ENABLED: true
 EBS_CSI_DRIVER_NAME: aws-ebs-csi-driver

--- a/roles/baseline/tasks/cluster-autoscaler.yaml
+++ b/roles/baseline/tasks/cluster-autoscaler.yaml
@@ -1,4 +1,17 @@
 ---
+
+- name: Set the default CLUSTER_AUTOSCALER_CHART_VERSION if not specified
+  block:
+    - name: Set the default CLUSTER_AUTOSCALER_CHART_VERSION based on K8s server minor version
+      set_fact:
+        CLUSTER_AUTOSCALER_CHART_VERSION: "{{ autoscalerVersions.PDBv1Support.api.chartVersion if K8S_VERSION|float >= 1.25 else autoscalerVersions.PDBv1beta1Support.api.chartVersion }}"
+  when:
+    - CLUSTER_AUTOSCALER_ENABLED
+    - CLUSTER_AUTOSCALER_CHART_VERSION|length == 0
+  tags:
+    - install
+    - update
+
 - name: Deploy cluster-autoscaler
   kubernetes.core.helm:
     name: "{{ CLUSTER_AUTOSCALER_NAME }}"
@@ -10,7 +23,7 @@
     kubeconfig: "{{ KUBECONFIG }}"
     wait: true
   when:
-  - CLUSTER_AUTOSCALER_ENABLED
+    - CLUSTER_AUTOSCALER_ENABLED
   tags:
     - install
     - update

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -35,16 +35,6 @@
   tags:
     - baseline
 
-- name: Include cluster-autoscaler
-  include_tasks: 
-    file: cluster-autoscaler.yaml
-  when:
-    - PROVIDER == "aws"
-    - CLUSTER_AUTOSCALER_ACCOUNT is defined
-    - CLUSTER_AUTOSCALER_ACCOUNT is not none
-  tags:
-    - baseline
-
 - name: Lookup K8s version info
   block:
     - name: Retrieve K8s cluster information
@@ -54,6 +44,16 @@
     - name: Set the K8s server version
       set_fact:
         K8S_VERSION: "{{ cluster_info.version.server.kubernetes.major + '.' + cluster_info.version.server.kubernetes.minor | regex_replace('\\+$', '') }}"
+  tags:
+    - baseline
+
+- name: Include cluster-autoscaler
+  include_tasks: 
+    file: cluster-autoscaler.yaml
+  when:
+    - PROVIDER == "aws"
+    - CLUSTER_AUTOSCALER_ACCOUNT is defined
+    - CLUSTER_AUTOSCALER_ACCOUNT is not none
   tags:
     - baseline
 


### PR DESCRIPTION
### Changes

Since the 2023.03 cadence adds support for K8s 1.25, we want to add support for that version across all the IAC projects. The usual process for this is just bumping the kubernetes_version & kubectl values so that we are in the +1/-1 range of all the versions the latest cadence supports.

Upon using viya4-deployment to baseline a 1.25 EKS cluster we ran into an issue installing the cluster-autoscaler, we needed to update it to a version that supports `PodDisruptionBudget policy/v1` since `policy/v1beta1` was deprecated as of 1.25. The new default `CLUSTER_AUTOSCALER_CHART_VERSION` we use for 1.25+ clusters is version 9.25.0. With the update to the autoscaler version we also needed to make changes on the viya4-iac-aws side to support this new version, updates were made to the cluster-autoscaler Role policy to line up with the recommendations from the [kubernetes/autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.25.0/cluster-autoscaler/cloudprovider/aws/README.md) so that it can properly function.

You can see the policy update in this PR https://github.com/sassoftware/viya4-iac-aws/pull/189 and the changes will be officially released as part of viya4-iac-aws:5.6.0

Note: for EKS clusters <1.25 we still use the `CLUSTER_AUTOSCALER_CHART_VERSION` default value of 9.9.2

In case a user uses version 5.5.0 of viya4-iac-aws or earlier to create their K8s 1.25 infrastructure in AWS (which would not include the Role policy updates), the troubleshooting documentation has steps remediate this by either using the latest version of viya4-iac-aws to update the Role policy or manual steps the user can take in the AWS IAM Console to achieve the same.

### Tests

Tested the following scenarios, more details in internal ticket.

Note: for all these scenarios I set `V4_CFG_CAS_WORKER_COUNT: 3` in my ansible vars to ensure that the autoscaler functioned and provisioned the additional CAS nodes. I also ensured upon uninstall the unused nodes were automatically removed.

| Scenario | Task | Provider | initial viya4-iac-aws version  | kubernetes_version | Order  | Cadence        | Orchestration       | Deployment Method | V4_CFG_CAS_WORKER_COUNT | CLUSTER_AUTOSCALER_CHART_VERSION | kubectl Version | Notes                                                                                              |
|----------|------|----------|--------------------------------|--------------------|--------|----------------|---------------------|-------------------|-------------------------|----------------------------------|-----------------|----------------------------------------------------------------------------------------------------|
| 1        | OOTB | AWS      | IAC-903                        | 1.22               | ***** | lts:2022.09    | Deployment Operator | Docker            | 3                       | 9.9.2 (default)                  | 1.24.10         |                                                                                                    |
| 2        | OOTB | AWS      | IAC-903                        | 1.24               | ***** | stable:2023.02 | Deployment Operator | Docker            | 3                       | 9.9.2 (default)                  | 1.24.10         |                                                                                                    |
| 3        | OOTB | AWS      | IAC-903                        | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         |                                                                                                    |
| 4        | OOTB | AWS      | 5.5.0                          | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         | expected initial autoscaler install failure, verified that troubleshooting option 1 resolved issue |
| 4        | OOTB | AWS      | 5.5.0                          | 1.25               | ***** | fast:2020      | Deployment Operator | Docker            | 3                       | 9.25.0 (default)                 | 1.24.10         | expected initial autoscaler install failure, verified that troubleshooting option 2 resolved issue |