### PR TITLE
feat: (IAC-892): set default kubectl to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.23.8
+ARG kubectl_version=1.24.10
 
 WORKDIR /build
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -42,7 +42,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.23.8 \
+	--build-arg kubectl_version=1.24.10 \
 	-t viya4-deployment .
 ```
 


### PR DESCRIPTION
# Changes:
With SAS Viya Platform supporting K8s 1.23, 1.24, and 1.25 in 2023.03 March release cadence, updating our supported kubectl version to 1.24.10 for it to be in the +/- 1 range of the supported versions.

# Tests: WIP