### PR TITLE
fix: (IAC-932) restore previous nfs-data mountPath in cas-add-nfs-mount.yaml transformer

### DIFF
--- a/roles/vdm/templates/transformers/cas-add-nfs-mount.yaml
+++ b/roles/vdm/templates/transformers/cas-add-nfs-mount.yaml
@@ -33,7 +33,7 @@ patch: |-
     path: /spec/controllerTemplate/spec/containers/0/volumeMounts/-
     value:
       name: nfs-data
-      mountPath: {{ V4_CFG_RWX_FILESTORE_DATA_PATH }}
+      mountPath: /mnt/viya-share/data
   - op: add
     path: /spec/controllerTemplate/spec/containers/0/volumeMounts/-
     value:


### PR DESCRIPTION
# Changes
Revert the unnecessary change to the nfs-data mountPath made [here](https://github.com/sassoftware/viya4-deployment/pull/366/files#diff-e18bf8b7b885bce91ca13a90fd4bca20d3e9d3eeaa8d6563437386229eb49b8aR35-R36) in PR #366

The original nfs-data mountPath of /mnt/viya-share/data in the cas-add-nfs-mount.yaml transformer should  be restored with this change.

# Testing
The originator of IAC-932, Jerry Read, will try out this update to verify that the previous mountPath value is restored with this update.

### Update:
Jerry used the f-iac-932 development branch to run DAC with DEPLOY=false and has confirmed that the cas-add-nfs-mount transformer generated from the updated template uses the restored mountPath for nfs-data.