### PR TITLE
feat: (IAC-920) DEPLOY Flag Should Also Control the Deployment Operator Un/Installation

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -37,7 +37,8 @@ Supported configuration variables are listed in the table below.  All variables 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| DEPLOY | Whether to deploy the SAS Viya platform and SAS Viya Platform Deployment Operator or stop at generating kustomization.yaml and manifests | bool | true | false | This flag can also prevent the uninstall of both the SAS Viya platform and SAS Viya Platform Deployment Operator | viya || LOADBALANCER_SOURCE_RANGES | IP addresses to allow to reach the ingress | [string] | | true | When deploying in a cloud environment, be sure to add the cloud NAT IP address. | baseline, viya |
+| DEPLOY | Whether to deploy the SAS Viya platform and SAS Viya Platform Deployment Operator or stop at generating kustomization.yaml and manifests | bool | true | false | This flag can also prevent the uninstall of both the SAS Viya platform and SAS Viya Platform Deployment Operator | viya |
+| LOADBALANCER_SOURCE_RANGES | IP addresses to allow to reach the ingress | [string] | | true | When deploying in a cloud environment, be sure to add the cloud NAT IP address. | baseline, viya |
 | BASE_DIR | Path to store persistent files | string | $HOME | false | | all |
 | KUBECONFIG | Path to kubeconfig file | string | | true | | viya |
 | V4_CFG_SITEDEFAULT | Path to sitedefault file | string | | false | When not set, [sitedefault](../examples/sitedefault.yaml) is used. | viya |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -37,8 +37,7 @@ Supported configuration variables are listed in the table below.  All variables 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| DEPLOY | Whether to deploy the SAS Viya platform or stop at generating kustomization.yaml and manifest | bool | true | false | | viya |
-| LOADBALANCER_SOURCE_RANGES | IP addresses to allow to reach the ingress | [string] | | true | When deploying in a cloud environment, be sure to add the cloud NAT IP address. | baseline, viya |
+| DEPLOY | Whether to deploy the SAS Viya platform and SAS Viya Platform Deployment Operator or stop at generating kustomization.yaml and manifests | bool | true | false | This flag can also prevent the uninstall of both the SAS Viya platform and SAS Viya Platform Deployment Operator | viya || LOADBALANCER_SOURCE_RANGES | IP addresses to allow to reach the ingress | [string] | | true | When deploying in a cloud environment, be sure to add the cloud NAT IP address. | baseline, viya |
 | BASE_DIR | Path to store persistent files | string | $HOME | false | | all |
 | KUBECONFIG | Path to kubeconfig file | string | | true | | viya |
 | V4_CFG_SITEDEFAULT | Path to sitedefault file | string | | false | When not set, [sitedefault](../examples/sitedefault.yaml) is used. | viya |

--- a/roles/vdm/tasks/deployment_operator.yaml
+++ b/roles/vdm/tasks/deployment_operator.yaml
@@ -227,6 +227,8 @@
         state: present
         namespace: "{{ V4_DEPLOYMENT_OPERATOR_NAMESPACE }}"
         kubeconfig: "{{ KUBECONFIG }}"
+      when:
+        - DEPLOY
   tags:
     - install
     - update
@@ -286,6 +288,7 @@
         - result.stdout|length > 0
   when:
     - cluster_sasdeployments.resources|length == 0
+    - DEPLOY
   tags:
     - uninstall
 
@@ -300,6 +303,7 @@
     state: absent
   when:
     - cluster_sasdeployments.resources|length == 0
+    - DEPLOY
   tags:
     - uninstall
 
@@ -310,5 +314,6 @@
   when:
     - V4_DEPLOYMENT_OPERATOR_SCOPE|lower == "cluster"
     - cluster_sasdeployments.resources|length == 0
+    - DEPLOY
   tags:
     - uninstall


### PR DESCRIPTION


### Changes
The `DEPLOY` variable should now also control the install/uninstall of the deployment operator, see table below for behavior changes.

#### Current Behavior

|                                  | viya,install DEPLOY:True | viya,install DEPLOY:False | viya,uninstall DEPLOY:True | viya,uninstall DEPLOY:False                     |
| -------------------------------- | ------------------------ | ------------------------- | -------------------------- | ----------------------------------------------- |
| Deployment Operator - Deployment | Deployed                 | Deployed                  | Deleted                    | Deleted                                         |
| Deployment Operator - Namespace  | Created                  | Created                   | Deleted                    | Deleted                                         |
| Viya - Namespace                 | Created                  | Created                   | Deleted                    | Retained                                        |
| sas-orchestration-secret         | Created                  | Created                   | Deleted                    | Retained                                        |
| Viya Deployment                  | Deployed                 | Only Manifest Generated   | Deleted                    | Retained & new manifest generated for uninstall |

#### Behavior After Updates

<table>
    <tr>
        <td></td>
        <td>viya,install DEPLOY:True</td>
        <td>viya,install DEPLOY:False</td>
        <td>viya,uninstall DEPLOY:True</td>
        <td>viya,uninstall DEPLOY:False</td>
    </tr>
    <tr>
        <td>Deployment Operator - Deployment</td>
        <td>Deployed</td>
        <td>

```diff
+ Only Manifest Generated
```

</td>
        <td>Deleted</td>
        <td>

```diff
+ Retained
```

</td>
    </tr>
    <tr>
        <td>Deployment Operator - Namespace</td>
        <td>Created</td>
        <td>Created</td>
        <td>Deleted</td>
        <td>

```diff
+ Retained
```

</td>
    </tr>
    <tr>
        <td>Viya - Namespace</td>
        <td>Created </td>
        <td>Created</td>
        <td>Deleted</td>
        <td>Retained</td>
    </tr>
    <tr>
        <td>sas-orchestration-secret</td>
        <td>Created</td>
        <td>Created</td>
        <td>Deleted</td>
        <td>Retained</td>
    </tr>
    <tr>
        <td>Viya Deployment</td>
        <td>Deployed</td>
        <td>Only Manifest Generated</td>
        <td>Deleted</td>
        <td>Retained &amp; new manifest generated for uninstall</td>
    </tr>
</table>

### Tests


| Scenarios | Steps                                                                                                                                                     | Provider | K8s Version       | Cadence   | Orchestration | Deployment Method | Behavior Observed                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-------------------|-----------|--------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1         | <ol>  <li>viya,install DEPLOY:True</li> <li>viya,install DEPLOY:False</li> <li>viya,uninstall DEPLOY:False</li> <li>Viya,uninstall DEPLOY:True</li> </ol> | GCP      | v1.24.10-gke.1200 | fast:2020 | DO           | Ansible           | <ol> <li>All the cluster resources should be created, ns, Viya, DO, sas-orchestration-secret and manifests generated</li> <li>deployment manifests regenerated, sas-orchestration-secret recreated, DO and Viya not redeployed</li> <li>Viya uninstall manifest generated, ns, Viya, DO, sas-orchestration-secret untouched in cluster</li> <li>Viya uninstall manifest generated, ns, Viya, DO, sas-orchestration-secret removed in cluster</li> </ol> |
| 2         | <ol>  <li>viya,install DEPLOY:False</li> </ol>                                                                                                            | GCP      | v1.24.10-gke.1200 | fast:2020 | DO           | Ansible           | <ol> <li>DO ns, Viya ns, and sas-orchestration-secret created. DO and Viya manifests generated by not deployed</li> </ol>                                                                                                                                                                                                                                                                                                                              |
| 3         | <ol>  <li>viya,install DEPLOY:True</li> <li>viya,install DEPLOY:False</li> <li>viya,uninstall DEPLOY:False</li> <li>Viya,uninstall DEPLOY:True</li> </ol> | GCP      | v1.24.10-gke.1200 | fast:2020 | Deploy | Ansible           | <ol> <li>All the cluster resources should be created, ns, Viya, sas-orchestration-secret, and manifests generated</li> <li>deployment manifest regenerated, sas-orchestration-secret recreated, Viya not redeployed</li> <li>Viya uninstall manifest generated, ns, Viya, sas-orchestration-secret untouched in cluster</li> <li>Viya uninstall manifest generated, ns, Viya, sas-orchestration-secret removed in cluster</li> </ol>                    |
| 4         | <ol>  <li>viya,install DEPLOY:False</li> </ol>                                                                                                            | GCP      | v1.24.10-gke.1200 | fast:2020 | Deploy | Ansible           | <ol> <li>Viya ns, and sas-orchestration-secret created.  Viya manifests generated by not deployed</li> </ol>                                                                                                                                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                      |

