### PR TITLE
fix: (IAC-938) filestore directory doesn't get created w/o V4_CFG_MANAGE_STORAGE

### DIFF
--- a/playbooks/playbook.yaml
+++ b/playbooks/playbook.yaml
@@ -36,7 +36,7 @@
         - JUMP_SVR_USER is defined
         - JUMP_SVR_PRIVATE_KEY is defined
         - V4_CFG_MANAGE_STORAGE is defined
-        - V4_CFG_MANAGE_STORAGE
+        - V4_CFG_MANAGE_STORAGE|bool
       tags:
         - viya
     - name: baseline role install

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -7,7 +7,7 @@
     - V4_CFG_RWX_FILESTORE_ENDPOINT is defined
     - V4_CFG_RWX_FILESTORE_PATH is defined
     - V4_CFG_MANAGE_STORAGE is defined
-    - V4_CFG_MANAGE_STORAGE
+    - V4_CFG_MANAGE_STORAGE|bool
   tags:
     - baseline
 

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -260,6 +260,31 @@
     - cas-onboard
     - offboard
 
+- name: Set V4_CFG_MANAGE_STORAGE default
+  block:
+    - name: Set V4_CFG_MANAGE_STORAGE default
+      set_fact:
+        V4_CFG_MANAGE_STORAGE: True
+      when: V4_CFG_MANAGE_STORAGE is not defined
+      tags:
+        - always
+    - name: Fail empty value
+      fail:
+        msg: "V4_CFG_MANAGE_STORAGE is defined but empty, supported values are true or false."
+      when: 
+        - V4_CFG_MANAGE_STORAGE is defined
+        - V4_CFG_MANAGE_STORAGE == ''
+      tags:
+        - always
+    - name: Fail unsupported values
+      fail:
+        msg: "The value provided for V4_CFG_MANAGE_STORAGE is unsupported, supported values are true or false."
+      when: 
+        - V4_CFG_MANAGE_STORAGE|lower != 'false' 
+        - V4_CFG_MANAGE_STORAGE|lower != 'true'
+      tags:
+        - always
+
 - name: migrations
   include_tasks: 
     file: migrations.yaml

--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -18,7 +18,7 @@
     - PROVIDER is not none
     - PROVIDER in ["azure","aws","gcp"]
     - V4_CFG_MANAGE_STORAGE is not none
-    - V4_CFG_MANAGE_STORAGE
+    - V4_CFG_MANAGE_STORAGE|bool
   tags:
     - install
     - update
@@ -42,6 +42,6 @@
     - PROVIDER is not none
     - PROVIDER == "azure"
     - V4_CFG_MANAGE_STORAGE is not none
-    - V4_CFG_MANAGE_STORAGE
+    - V4_CFG_MANAGE_STORAGE|bool
   tags:
     - uninstall


### PR DESCRIPTION
# Changes
The entry for V4_CFG_MANAGE_STORAGE in CONFIG-VARS.md indicates that it defaults to true but is not required. This PR ensures that if a value for V4_CFG_MANAGE_STORAGE has not been defined in ansible-vars or via a command line flag, it will be set to true. Validation checks were added to fail and exit with a message for empty or unsupported values.
# Tests
Verified these scenarios, see internal ticket for additional details:
| Scenario | Method | Description | tags | Order | Verification |
|:-|:-|:-|:-|:-|:-|
| 1 | ansible | V4_CFG_MANAGE_STORAGE not defined in ansible-vars and not specified on command line | "baseline,cluster-monitoring,install" | 2023.02 | DAC sets V4_CFG_MANAGE_STORAGE=true, nfs-subdir-external-provisioner creates both storageClasses, v4m storage class is created |
| 2 | ansible | V4_CFG_MANAGE_STORAGE not defined in ansible-vars and not specified on command line | "viya,install" | 2023.02 | DAC sets V4_CFG_MANAGE_STORAGE=true, jump-server-role create folders task runs as expected, verified astores, bin, data, homes folders exist under /export location, verified sas-cas-server-default-controller pod successfully mounted /export/deploy/data and /export/deploy/homes
| 3 | ansible | V4_CFG_MANAGE_STORAGE not defined in ansible-vars and not specified on command line | "baseline,cluster-monitoring,viya,uninstall" | 2023.02 | DAC sets V4_CFG_MANAGE_STORAGE=true, successful uninstall of all installed components
| 4| ansible | V4_CFG_MANAGE_STORAGE defined as false in ansible-vars and not specified on command line | "baseline,install" | 2023.02 | skip nfs-subdir-external-provisioner deployment, no storage classes created |
| 5| ansible | V4_CFG_MANAGE_STORAGE defined as false in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as true on command line | "baseline,install" | 2023.02 | nfs-subdir-external-provisioner creates both storageClasses |
| 6| ansible | V4_CFG_MANAGE_STORAGE defined as false in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as true on command line | "cluster-monitoring,install" | 2023.02 | v4m storage class created, cluster-monitoring successfully installed with PVCs bound to v4m SC for alertmanager, prometheus and granfana |
| 7| ansible | V4_CFG_MANAGE_STORAGE defined as false in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as true on command line | "baseline,cluster-monitoring,uninstall" | 2023.02 | successful uninstall of all installed components
| 8| ansible | V4_CFG_MANAGE_STORAGE not defined in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as false on command line | "baseline,install" | 2023.02 | skip nfs-subdir-external-provisioner deployment, no storage classes created |
| 9| ansible | V4_CFG_MANAGE_STORAGE defined as true in ansible-vars and not specified on command line | "baseline,cluster-monitoring,install" | 2023.02 | nfs-subdir-external-provisioner creates both storageClasses, v4m storage class created, cluster-monitoring successfully installed with PVCs bound to v4m SC for alertmanager, prometheus and granfana |
| 10| ansible | V4_CFG_MANAGE_STORAGE defined as true in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as '' on command line | "baseline,install" | 2023.02 | DAC exits with message "V4_CFG_MANAGE_STORAGE is defined but empty, supported values are true or false." |
| 11| ansible | V4_CFG_MANAGE_STORAGE defined as true in ansible-vars and V4_CFG_MANAGE_STORAGE override specified as 'ture' on command line | "baseline,install" | 2023.02 | DAC exits with message "The value provided for V4_CFG_MANAGE_STORAGE is unsupported, supported values are true or false." |