### PR TITLE
fix: (IAC-953): Fixed multi-tenant onboard command failure

### DIFF
--- a/roles/multi-tenancy/tasks/main.yaml
+++ b/roles/multi-tenancy/tasks/main.yaml
@@ -8,6 +8,7 @@
 - name: Include Orchestration Tooling
   include_tasks: ../../orchestration-common/tasks/orchestration_tooling.yaml
   tags:
+    - onboard
     - cas-onboard
     - offboard
 

--- a/roles/orchestration-common/tasks/orchestration_tooling.yaml
+++ b/roles/orchestration-common/tasks/orchestration_tooling.yaml
@@ -12,6 +12,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -32,6 +33,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -44,6 +46,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -57,6 +60,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -69,6 +73,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -81,6 +86,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -117,6 +123,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -131,6 +138,7 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard
 
@@ -144,5 +152,6 @@
     - install
     - uninstall
     - update
+    - onboard
     - cas-onboard
     - offboard


### PR DESCRIPTION
# Changes:
In PR #395 code was updated to utilize kustomize from within the sas-orchestration image for all tasks, however "onboard" tag was missing from the new tasks in `orchestration-common/tasks/orchestration_tooling.yaml`. This resulted in Multi-tenant onboard command failure: `ORCHESTRATION_TOOLING_DIRECTORY is undefined`.

This change fixes the above issue by adding the missing tag "onboard" to the orchestration_tooling tasks.

# Tests:
Verified following scenarios, see details in internal ticket:

|Scenario|Task|Cadence|K8s Version|Execution Method|Orchestration|
|:----|:----|:----|:----|:----|:----|
|1|OOTB + Multi-Tenant|stable:2023.02|v1.25|Docker|Deploy Command|
|2|OOTB + Multi-Tenant|Fast:2020|v1.24|Ansible|Deployment Operator|