### PR TITLE
docs: (IAC-930) sas-data-agent-server-colocated statefulset caused "/spec/volumeClaimTemplates/0/spec/storageClassName": missing value during update

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -122,7 +122,7 @@ Note: As documented in our [CONFIG-VARS.md](./CONFIG-VARS.md), EKS 1.24 and lowe
 
 ### Solution:
 
-Note: If you used viya4-iac-aws:5.6.0 or never to create your infrastructure, these steps are not applicable for you. This role & policy should already be correct. 
+Note: If you used viya4-iac-aws:5.6.0 or newer to create your infrastructure, these steps are not applicable for you. This role & policy should already be correct. 
 
 1. Scale the `cluster-autoscaler-aws-cluster-autoscaler` deployment down to 0
       ```bash


### PR DESCRIPTION
# Changes
Adds troubleshooting documentation providing the symptom and resolution for a kustomize error users might encounter while deploying the SAS Viya Platform with viya4-deployment releases prior to 5.4.0.

The remedy for users that run into this problem is to use viya4-deployment [release 5.4.0](https://github.com/sassoftware/viya4-deployment/releases/tag/5.4.0) or later.

