### PR TITLE
docs: (IAC-916) V4M monitoring and logging fails to install with open-source K8s because of the missing v4m SC

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -166,7 +166,7 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 
 #### Open Source Kubernetes
 
-When deploying `cluster-logging` or `cluster-monitoring` applications to kubernetes cluster infrastructure provisioned with the [Open Source Kubernetes viya4-iac-k8s](https://github.com/sassoftware/viya4-iac-k8s) project, you must set `V4M_STORAGECLASS` to `local-storage` regardless of the value set for `V4_CFG_MANAGE_STORAGE`.
+When deploying `cluster-logging` or `cluster-monitoring` applications to kubernetes cluster infrastructure provisioned with the [Open Source Kubernetes viya4-iac-k8s](https://github.com/sassoftware/viya4-iac-k8s) project, you must explicitly set the value for `V4M_STORAGECLASS` to a pre-existing Storage Class (for example: `local-storage`)  regardless of the value set for `V4_CFG_MANAGE_STORAGE`. While other storage classes can be used, the `local-storage` class is **recommended** for the Viya Monitoring and Loggging tools.
 
 ### Monitoring
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -164,6 +164,10 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 | V4M_NODE_PLACEMENT_ENABLE | Whether to enable workload node placement for viya4-monitoring-kubernetes stack | bool | false | false | | cluster-logging, cluster-monitoring, viya-monitoring |
 | V4M_STORAGECLASS | StorageClass name | string | v4m | false | When V4_CFG_MANAGE_STORAGE is false, set to the name of your pre-existing StorageClass that supports ReadWriteOnce. | cluster-logging, cluster-monitoring, viya-monitoring |
 
+#### Open Source Kubernetes
+
+When deploying `cluster-logging` or `cluster-monitoring` applications to kubernetes cluster infrastructure provisioned with the [Open Source Kubernetes viya4-iac-k8s](https://github.com/sassoftware/viya4-iac-k8s) project, you must set `V4M_STORAGECLASS` to `local-storage` regardless of the value set for `V4_CFG_MANAGE_STORAGE`.
+
 ### Monitoring
 
 | Name | Description | Type | Default | Required | Notes | Tasks |


### PR DESCRIPTION
# Changes
Adds requested instructions for setting `V4M_STORAGECLASS` value to `local-storage` in ansible-vars.yaml when using [viya4-deployment](https://github.com/sassoftware/viya4-deployment.git) to deploy `cluster-logging` and `cluster-monitoring` applications on kubernetes clusters provisioned with the [open source kubernetes IaC](https://github.com/sassoftware/viya4-iac-k8s) project