### PR TITLE
docs: (IAC-958) update DAC SingleStore.md to include iac-aws and oss-k8s

### DIFF
--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -8,9 +8,25 @@ If your SAS software order included SAS Viya with SingleStore, additional requir
 
 ## Deploying SAS Viya with SingleStore Using SAS Viya 4 Deployment
 
-You can deploy SAS Viya with SingleStore into a Kubernetes cluster that is running in Microsoft Azure. The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+You can deploy SAS Viya with SingleStore into a Kubernetes cluster running under:
+- Azure Kubernetes Service (AKS) in Microsoft Azure
+- Elastic Kubernetes Service (EKS) in Amazon Web Services
+- Open Source Kubernetes on your own machines
 
-Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an Azure cluster suitable for deploying SAS Viya and SingleStore.
+### Azure Kubernetes Service Cluster in Microsoft Azure
+
+The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an AKS cluster suitable for deploying SAS Viya and SingleStore.
+
+### Elastic Kubernetes Service Cluster in Amazon Web Services
+
+The [SAS Viya 4 Infrastructure as Code (IaC) for Amazon Web Services (AWS)](https://github.com/sassoftware/viya4-iac-aws) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-aws/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an EKS cluster suitable for deploying SAS Viya and SingleStore.
+
+### Open Source Kubernetes Cluster
+
+The [SAS Viya 4 Infrastructure as Code (IaC) for Open Source Kubernetes](https://github.com/sassoftware/viya4-iac-k8s) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-k8s/blob/main/examples/vsphere/sample-terraform-static-singlestore.tfvars) for Terraform configuration values that create an Open Source Kubernetes cluster suitable for deploying SAS Viya and SingleStore.
 
 ## Customizing SingleStore Deployment Overlays
 

--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -10,25 +10,25 @@ If your SAS software order included SAS Viya with SingleStore, additional requir
 
 You can deploy SAS Viya with SingleStore into a Kubernetes cluster running under:
 - Azure Kubernetes Service (AKS) in Microsoft Azure
-- Elastic Kubernetes Service (EKS) in Amazon Web Services
+- Elastic Kubernetes Service (EKS) in Amazon Web Services (AWS)
 - Open Source Kubernetes on your own machines
 
-## Cluster provisioning for SAS Viya with SingleStore
+## Cluster Provisioning for SAS Viya with SingleStore
 
-### Azure Kubernetes Service Cluster in Microsoft Azure
+### Azure Kubernetes Service (AKS) Cluster in Microsoft Azure
 
-The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
-Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an AKS cluster suitable for deploying SAS Viya and SingleStore.
+The [SAS Viya 4 IaC for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an AKS cluster that is suitable for deploying SAS Viya and SingleStore.
 
-### Elastic Kubernetes Service Cluster in Amazon Web Services
+### EKS Cluster in AWS
 
-The [SAS Viya 4 Infrastructure as Code (IaC) for Amazon Web Services (AWS)](https://github.com/sassoftware/viya4-iac-aws) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
-Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-aws/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an EKS cluster suitable for deploying SAS Viya and SingleStore.
+The [SAS Viya 4 IaC for AWS](https://github.com/sassoftware/viya4-iac-aws) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-aws/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an EKS cluster that is suitable for deploying SAS Viya and SingleStore.
 
 ### Open Source Kubernetes Cluster
 
 The [SAS Viya 4 Infrastructure as Code (IaC) for Open Source Kubernetes](https://github.com/sassoftware/viya4-iac-k8s) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 
-Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-k8s/blob/main/examples/vsphere/sample-terraform-static-singlestore.tfvars) for Terraform configuration values that create an Open Source Kubernetes cluster suitable for deploying SAS Viya and SingleStore.
+Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-k8s/blob/main/examples/vsphere/sample-terraform-static-singlestore.tfvars) for Terraform configuration values that create an Open Source Kubernetes cluster that is suitable for deploying SAS Viya and SingleStore.
 
 ## Customizing SingleStore Deployment Overlays
 

--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -13,6 +13,8 @@ You can deploy SAS Viya with SingleStore into a Kubernetes cluster running under
 - Elastic Kubernetes Service (EKS) in Amazon Web Services
 - Open Source Kubernetes on your own machines
 
+## Cluster provisioning for SAS Viya with SingleStore
+
 ### Azure Kubernetes Service Cluster in Microsoft Azure
 
 The [SAS Viya 4 Infrastructure as Code (IaC) for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS Viya with SingleStore deployments. 


### PR DESCRIPTION
# Changes
The DAC SingleStore.md has a [section](https://github.com/sassoftware/viya4-deployment/blob/bc2992bc6f79630678d259a1fcfbf79a2bb18e14/docs/user/SingleStore.md#deploying-sas-viya-with-singlestore-using-sas-viya-4-deployment) for Deploying SAS Viya with SingleStore Using SAS Viya 4 Deployment.    It mentions using viya4-iac-azure.  We need to add viya4-iac-aws and viya4-iac-k8s.