### PR TITLE
feat: (IAC-893) Ingress-nginx service annotation added for Azure LB probing issue

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -5,7 +5,7 @@
   - [SAS Viya Orchestration Tool](#sas-viya-orchestration-tool)
   - [SAS Viya Deployment Operator](#sas-viya-deployment-operator)
   - [EKS - Cluster Autoscaler Installation](#eks---cluster-autoscaler-installation)
-  - [Ingress-Nginx issue - Unable to access SAS Viya Platform Webapps](#ingress-nginx-issue---unable-to-access-sas-viya-platform-webapps)
+  - [Ingress-Nginx issue - Unable to access SAS Viya Platform web apps](#ingress-nginx-issue---unable-to-access-sas-viya-platform-web-apps)
 
 ## Debug Mode
 Debug mode can be enabled by adding "-vvv" to the end of the docker or ansible commands
@@ -146,9 +146,9 @@ Note: If you used viya4-iac-aws:5.6.0 or never to create your infrastructure, th
       kubectl scale --replicas=1 deployment/cluster-autoscaler-aws-cluster-autoscaler
       ```
 
-## Ingress-Nginx issue - Unable to access SAS Viya Platform WebApps
+## Ingress-Nginx issue - Unable to access SAS Viya Platform web apps
 ### Symptom:
-After upgrading your AKS cluster's Kubernetes version to 1.24 or later, you are unable to access the SAS Viya Platform WebApps. All the pods are running and errors are only seen in ingress-nginx logs:
+After upgrading your AKS cluster's Kubernetes version to 1.24 or later, you are unable to access the SAS Viya Platform web apps. All the pods are running and errors are only seen in ingress-nginx logs:
 
 ```bash
 W0320 20:15:25.141987       7 controller.go:1354] Using default certificate
@@ -177,7 +177,7 @@ To resolve this issue the ingress-nginx version should be 1.3.0 (or later) with 
 > --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz
 
 ### Solution:
-For Users upgrading their AKS cluster's Kubernetes version to 1.24 (or later) and used viya4-deployment v6.3.0 (or prior) for the SAS Viya Platform deployment, please use viya4-deployment v6.4.0 (or later) and re-run the baseline install task.
+For Users upgrading their AKS cluster's Kubernetes version to 1.24 (or later) and used viya4-deployment v6.3.0 (or prior) for the SAS Viya Platform deployment, you must use viya4-deployment v6.4.0 (or later) and re-run the baseline install task.
 
 If you prefer to continue using the existing viya4-deployment version then add the following in your ansible-var.yaml and re-run baseline install task :
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -63,6 +63,13 @@ INGRESS_NGINX_CONFIG:
           command: ["/bin/sh", "-c", "sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done"]
     terminationGracePeriodSeconds: 600
 
+# Add annotation to include Azure load-balancer health probe request path
+INGRESS_NGINX_AZURE_LB_HEALTH_PROBE_CONFIG:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+
 # Update default load-balancer for AWS to be NLB
 INGRESS_NGINX_AWS_NLB_CONFIG:
   controller:

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -37,6 +37,15 @@
     - install
     - update
 
+- name: Update INGRESS_NGINX_CONFIG to add Azure load-balancer health probe request path
+  set_fact:
+    INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG|combine(INGRESS_NGINX_AZURE_LB_HEALTH_PROBE_CONFIG, recursive=True)}}"
+  when:
+    - PROVIDER == "azure"
+  tags:
+    - install
+    - update    
+
 - name: Apply Mitigation for CVE-2021-25742
   block:
     - name: Retreive K8s cluster information


### PR DESCRIPTION
# Changes
For Users upgrading their AKS cluster's Kubernetes version to 1.24 (or later) and used viya4-deployment v6.3.0 (or prior) for the SAS Viya Platform deployment were unable to access the SAS Viya Platform WebApps.

This issue is related to Azure LoadBalancer’s probing. The appProtocol support inside cloud provider has broken ingress-nginx for AKS clusters >=1.22. The issue was caused by two reasons:
* the new version of nginx ingress controller added appProtocol and its probe path has to be `/healthz`;
* the new version of cloud-controller-manager added HTTP probing with default path `/` for appProtocol=http services.

To resolve this issue the ingress-nginx version should be 1.3.0 (or later) with the following annotation configured :
> --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz

# Tests:
On the following scenarios verified the service annotation was added, deployment was successful and WebApps were accessible, see details in internal ticket:

|Scenario|Task|Provider|Cadence|kubernetes_version|
|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.23|
|2|Upgrade to 1.24 |Azure|fast:2020|1.24|
|3|OOTB|Azure|Stable 2023.03|1.24|
|3|OOTB|Azure|fast:2020|1.25|