### PR TITLE
fix: Update kubernetes-sigs nfs-provisioner

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -414,7 +414,7 @@ The NFS client is currently supported by the newer nfs-subdir-external-provision
 | NFS_CLIENT_NAMESPACE | nfs-subdir-external-provisioner Helm installation namespace | string | nfs-client | false | | baseline |
 | NFS_CLIENT_CHART_URL | nfs-subdir-external-provisioner Helm chart URL | string | Go [here](https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/) for more information. | false | | baseline |
 | NFS_CLIENT_CHART_NAME | nfs-subdir-external-provisioner Helm chart name | string | nfs-subdir-external-provisioner | false | | baseline |
-| NFS_CLIENT_CHART_VERSION | nfs-subdir-external-provisioner Helm chart version | string | 4.0.8| false | | baseline |
+| NFS_CLIENT_CHART_VERSION | nfs-subdir-external-provisioner Helm chart version | string | 4.0.18| false | | baseline |
 | NFS_CLIENT_CONFIG | nfs-subdir-external-provisioner Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 
 ### Postgres NFS Client
@@ -426,7 +426,7 @@ The Postgres NFS client is currently supported by the nfs-subdir-external-provis
 | PG_NFS_CLIENT_NAMESPACE | nfs-subdir-external-provisioner Helm installation namespace | string | nfs-client | false | | baseline |
 | PG_NFS_CLIENT_CHART_URL | nfs-subdir-external-provisioner Helm chart URL | string | Go [here](https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/) for more information. | false | | baseline |
 | PG_NFS_CLIENT_CHART_NAME | nfs-subdir-external-provisioner Helm chart name | string | nfs-subdir-external-provisioner | false | | baseline |
-| PG_NFS_CLIENT_CHART_VERSION | nfs-subdir-external-provisioner Helm chart version | string | 4.0.8| false | | baseline |
+| PG_NFS_CLIENT_CHART_VERSION | nfs-subdir-external-provisioner Helm chart version | string | 4.0.18| false | | baseline |
 | PG_NFS_CLIENT_CONFIG | nfs-subdir-external-provisioner Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -84,7 +84,7 @@ NFS_CLIENT_NAME: nfs-subdir-external-provisioner-sas
 NFS_CLIENT_NAMESPACE: nfs-client
 NFS_CLIENT_CHART_NAME: nfs-subdir-external-provisioner
 NFS_CLIENT_CHART_URL: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
-NFS_CLIENT_CHART_VERSION: 4.0.8
+NFS_CLIENT_CHART_VERSION: 4.0.18
 NFS_CLIENT_CONFIG:
   nfs:
     server: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"
@@ -103,7 +103,7 @@ PG_NFS_CLIENT_NAME: nfs-subdir-external-provisioner-pg-storage
 PG_NFS_CLIENT_NAMESPACE: nfs-client
 PG_NFS_CLIENT_CHART_NAME: nfs-subdir-external-provisioner
 PG_NFS_CLIENT_CHART_URL: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
-PG_NFS_CLIENT_CHART_VERSION: 4.0.8
+PG_NFS_CLIENT_CHART_VERSION: 4.0.18
 PG_NFS_CLIENT_CONFIG:
   nfs:
     server: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"


### PR DESCRIPTION
# Changes
Update the client chart version for the nfs-subdir-external-provisioner from 4.0.8 to 4.0.18 so that we will pull the provisioner image from the `registry.k8s.io` container registry instead of the deprecated `k8s.gcr.io` container registry.

# Testing
|Scenario | DAC deployment tasks | Notes |
|-|-|-|
|Prior to chart version change | "baseline, cluster-logging, viya, install" | Filtered list indicates the only image pulled from k8s.gcr.io as: `k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2`
|After chart version change| "baseline, cluster-logging, cluster-monitoring, viya, install" | All pods stabilized, `sas` and `pg-storage` related PVCs are bound with no errors. Filtered list shows the new CR location for the image above as: `registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2`

The following command was used to create the list of image locations for containers present in the deployment:
```
kubectl get pods --all-namespaces \
-o jsonpath="{.items[*].spec.containers[*].image}" |\
tr -s '[[:space:]]' '\n' |\
sort |\
uniq -c
```

### Information from Stephen:
Due to the pending depreciation of k8s.gcr.io and redirect to registry.k8s.io, we need to move to a newer version of kubernetes-sigs for the nfs-subdir-external-provisioner to get the image registry update. This is affecting some of our environments where we have stricter controls in place and the redirect is not working. Eventually the redirect will be removed as well, so it is probably a good time to do this.

More information:
https://kubernetes.io/blog/2023/03/10/image-registry-redirect/
https://www.reddit.com/r/devops/comments/11sm10g/deprecation_alert_mar_20_traffic_from_the_old/