### PR TITLE
fix: (IAC-960) Remediate DAC critical vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 
 # Installation
 FROM baseline
-ARG helm_version=3.8.1
+ARG helm_version=3.9.4
 ARG aws_cli_version=2.7.22
 ARG gcp_cli_version=409.0.0
 


### PR DESCRIPTION
Fixes issue #414

# Changes
- Update helm version used in docker image from 3.8.1 to 3.9.4
- Rebuild docker image with the latest ubuntu 22.04 image available from docker hub

# Testing
- Rebuilt the viya4-deployment docker image with helm 3.9.4 using the docker build --no-cache option to enforce pulling the latest ubuntu 22.04 ([jammy-20230308](https://hub.docker.com/layers/library/ubuntu/jammy-20230308/images/sha256-7a57c69fe1e9d5b97c5fe649849e79f2cfc3bf11d10bbd5218b4eb61716aebe6?context=explore)) image from docker hub
- Used docker scout CLI tool to verify the list of critical CVEs present in the existing viya4-deployment:6.3.0 image
- Re-ran docker scout against the rebuilt viya4-deployment docker image to verify that no critical CVEs are present in it

viya4-deployment development tests, see internal ticket for additional details.
Ran the following Viya 4 deployments using the rebuilt viya4-deployment docker image containing zero critical CVEs.
| Scenario | DAC version | Provider | Cadence| K8s version| helm version| Method | DAC tags| Result |
|-|-|-|-|-|-|-|-|-|
| 1 | iac-960 branch | Azure | fast:2020| 1.24.6| 3.9.4 | docker | "baseline,cluster-logging,cluster-monitoring,viya,install" | Viya deployment stabilized. Successful viya_admin login via UI |
| 2 | iac-960 branch | GCP | stable:2023.03 | 1.24.10 | 3.9.4 | docker | "baseline,cluster-logging,cluster-monitoring,viya,install" | Viya deployment stabilized. Successful viya_admin login via UI. Successful navigation to SASDrive, SAS Environment Mgr and SAS Studio applications | 
