### PR TITLE
fix: (IAC-956) Handle Special Characters for Orchestration Credentials

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -145,14 +145,6 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 | V4_CFG_CR_PASSWORD | Container registry password | string | | false | By default, credentials are included in the downloaded deployment assets. See notes below. | viya |
 | V4_CFG_CR_URL | Container registry server | string | https://cr.sas.com | false | | viya |
 
-**Notes:**
-Ansible will attempt templating any string that contains any Jinja2 delimiters. If you container registry credentials contains any of the following [sequence of characters](https://jinja.palletsprojects.com/en/2.11.x/templates/#synopsis) within it, and you are running into templating errors try marking the value as [unsafe](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings) so that Ansible will not attempt to template the value.
-
-Example:
-```yaml
-V4_CFG_CR_PASSWORD: !unsafe "my{%crpassword"
-```
-
 ## Ingress
 
 | Name | Description | Type | Default | Required | Notes | Tasks |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -141,9 +141,17 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_CR_USER | Container registry username | string | | false | By default, credentials are included in the downloaded deployment assets. | viya |
-| V4_CFG_CR_PASSWORD | Container registry password | string | | false | By default, credentials are included in the downloaded deployment assets. | viya |
+| V4_CFG_CR_USER | Container registry username | string | | false | By default, credentials are included in the downloaded deployment assets. See notes below. | viya |
+| V4_CFG_CR_PASSWORD | Container registry password | string | | false | By default, credentials are included in the downloaded deployment assets. See notes below. | viya |
 | V4_CFG_CR_URL | Container registry server | string | https://cr.sas.com | false | | viya |
+
+**Notes:**
+Ansible will attempt templating any string that contains any Jinja2 delimiters. If you container registry credentials contains any of the following [sequence of characters](https://jinja.palletsprojects.com/en/2.11.x/templates/#synopsis) within it, and you are running into templating errors try marking the value as [unsafe](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings) so that Ansible will not attempt to template the value.
+
+Example:
+```yaml
+V4_CFG_CR_PASSWORD: !unsafe "my{%crpassword"
+```
 
 ## Ingress
 

--- a/roles/orchestration-common/tasks/orchestration_tooling.yaml
+++ b/roles/orchestration-common/tasks/orchestration_tooling.yaml
@@ -55,10 +55,12 @@
 
 # The ansible log output will have escape characters when the fact is set, if the parsed string contains symbols.
 # This is expected and required to avoid Jinja2 templating issues in the tasks that use these two facts.
+# Note we are also escaping '{%' which to resolve templating issues around Jinja statements
+# https://jinja.palletsprojects.com/en/2.11.x/templates/#synopsis
 - name: orchestration tooling - set registry credentials if using defaults
   set_fact:
-    ORCHESTRATION_CR_USER: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('username=(.+)', '\\1') | first | regex_escape() }}"
-    ORCHESTRATION_CR_PASSWORD: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('password=(.+)', '\\1') | first | regex_escape() }}"
+    ORCHESTRATION_CR_USER: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('username=(.+)', '\\1') | first | regex_escape() | regex_replace('{%','{\\%') }}"
+    ORCHESTRATION_CR_PASSWORD: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('password=(.+)', '\\1') | first | regex_escape() | regex_replace('{%','{\\%') }}"
   when:
     - ORCHESTRATION_CR_USER is none
   tags:
@@ -70,10 +72,10 @@
     - offboard
 
 # The ansible log output will have escape characters for ORCHESTRATION_CR_USER & ORCHESTRATION_CR_PASSWORD.
-# if the parsed facts contain symbols. This is expected and required to avoid Jinja2 templating issues.
+# if the parsed creds contain symbols. This is expected and required to avoid Jinja2 templating issues.
 - name: orchestration tooling - Download orchestration tooling image
   command: |
-    skopeo copy docker://{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }} oci-archive:{{ ORCHESTRATION_TOOLING_ARCHIVE }} --src-creds {{ ORCHESTRATION_CR_USER }}:{{ ORCHESTRATION_CR_PASSWORD }}
+    skopeo copy docker://{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }} oci-archive:{{ ORCHESTRATION_TOOLING_ARCHIVE }} --src-creds {{ ORCHESTRATION_CR_USER|string }}:{{ ORCHESTRATION_CR_PASSWORD|string }}
   when:
     - deployment_tooling == "docker"
   tags:
@@ -135,12 +137,9 @@
     - offboard
 
 # The ansible log output will have escape characters for ORCHESTRATION_CR_USER & ORCHESTRATION_CR_PASSWORD.
-# if the parsed facts contain symbols. This is expected and required to avoid Jinja2 templating issues.
+# if the parsed creds contain symbols. This is expected and required to avoid Jinja2 templating issues.
 - name: orchestration tooling - log into V4_CFG_CR_HOST
-  community.docker.docker_login:
-    registry_url: "{{ V4_CFG_CR_HOST }}"
-    username: "{{ ORCHESTRATION_CR_USER }}"
-    password: "{{ ORCHESTRATION_CR_PASSWORD }}"
+  command: 'docker login -u {{ ORCHESTRATION_CR_USER|string}} -p {{ ORCHESTRATION_CR_PASSWORD|string }} {{ V4_CFG_CR_HOST }}'
   when:
     - deployment_tooling == "ansible"
   tags:

--- a/roles/orchestration-common/tasks/orchestration_tooling.yaml
+++ b/roles/orchestration-common/tasks/orchestration_tooling.yaml
@@ -55,8 +55,8 @@
 
 - name: orchestration tooling - set registry credentials if using defaults
   set_fact:
-    ORCHESTRATION_CR_USER: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('username=(.+)', '\\1') | first }}"
-    ORCHESTRATION_CR_PASSWORD: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('password=(.+)', '\\1') | first }}"
+    ORCHESTRATION_CR_USER: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('username=(.+)', '\\1') | first | regex_escape() }}"
+    ORCHESTRATION_CR_PASSWORD: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('password=(.+)', '\\1') | first | regex_escape() }}"
   when:
     - ORCHESTRATION_CR_USER is none
   tags:

--- a/roles/orchestration-common/tasks/orchestration_tooling.yaml
+++ b/roles/orchestration-common/tasks/orchestration_tooling.yaml
@@ -53,6 +53,8 @@
     - cas-onboard
     - offboard
 
+# The ansible log output will have escape characters when the fact is set, if the parsed string contains symbols.
+# This is expected and required to avoid Jinja2 templating issues in the tasks that use these two facts.
 - name: orchestration tooling - set registry credentials if using defaults
   set_fact:
     ORCHESTRATION_CR_USER: "{{ lookup('file', '{{DEPLOY_DIR}}/sas-bases/base/secrets.yaml') | regex_search('username=(.+)', '\\1') | first | regex_escape() }}"
@@ -67,6 +69,8 @@
     - cas-onboard
     - offboard
 
+# The ansible log output will have escape characters for ORCHESTRATION_CR_USER & ORCHESTRATION_CR_PASSWORD.
+# if the parsed facts contain symbols. This is expected and required to avoid Jinja2 templating issues.
 - name: orchestration tooling - Download orchestration tooling image
   command: |
     skopeo copy docker://{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }} oci-archive:{{ ORCHESTRATION_TOOLING_ARCHIVE }} --src-creds {{ ORCHESTRATION_CR_USER }}:{{ ORCHESTRATION_CR_PASSWORD }}
@@ -130,6 +134,8 @@
     - cas-onboard
     - offboard
 
+# The ansible log output will have escape characters for ORCHESTRATION_CR_USER & ORCHESTRATION_CR_PASSWORD.
+# if the parsed facts contain symbols. This is expected and required to avoid Jinja2 templating issues.
 - name: orchestration tooling - log into V4_CFG_CR_HOST
   community.docker.docker_login:
     registry_url: "{{ V4_CFG_CR_HOST }}"


### PR DESCRIPTION
### Changes

Changes were made to how the task that parses the default credentials from `{{ DEPLOY_DIR }}/sas-bases/base/secrets.yaml`, we now are  properly escaping parsed credentials to handle the case where they may contain Jinja2 special characters. Documentation was also added to tell users to add the `!unsafe`  denotation who have special Jinja2 character sequences in credentials the put in their ansible-vars. This tells ansible not to "templatize" the values.

### Tests

**Methodology:**

The task that parses and incorrectly escapes credentials with special [Jinja2 characters](https://jinja.palletsprojects.com/en/2.11.x/templates/#synopsis) is  `orchestration tooling - set registry credentials if using defaults`. This task will only run if a user did not define `ORCHESTRATION_CR_USER`/`ORCHESTRATION_CR_PASSWORD` and will look inside the `{{ DEPLOY_DIR }}/sas-bases/base/secrets.yaml` file for the credentials that were provided by SAS for the default CR.

These credentials that are randomly generated and provided by SAS and there is no method as far as I am aware to customize it, so we will have to "indirectly" test the credentials with the special Jinja2 characters. I will initially deploy my own Harbor container registry to an internal VM instance and use mirrormgr to mirror SAS Viya platform images to it. Then inside Harbor I will create users that have the "special" characters within their password.

My process then will be to pause mid-execution and manually update the credential entry in `{{ DEPLOY_DIR }}/sas-bases/base/secrets.yaml` with the user I just created in Harbor and see if the characters get properly escaped. I am expecting that the skopeo download or docker pull of the sas-orchestration image will successful, and we should no longer see a templating error that looks like: `original message: template error while templating string...`


| Scenario | Provider | Order  | Cadence            | Deployment Method | DEPLOY | Credentials (created this user in my personal harbor instance) | Notes                                                                 |
|----------|----------|--------|--------------------|-------------------|--------|----------------------------------------------------------------|-----------------------------------------------------------------------|
| 1        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user1:{%foo{%12345A                                            |                                                                       |
| 2        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user2:bar{{12345A                                              |                                                                       |
| 3        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user3:{#testuser{#12345A                                       |                                                                       |
| 4        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user4:#mytest##account#12345A                                  |                                                                       |
| 5        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user5:*+?\.^{]$&|Reg1                                          | regex special characters                                              |
| 6        | Azure    | ****** | fast:2020          | Ansible           | FALSE  | user6:A1{%a%}{{b}}{#c#}#d##                                    |                                                                       |
| 7        | Azure    | ****** | stable:2023.03 R/S | Ansible           | TRUE   | Unmodified                                                     | used cr.sas.com to verified all images were still successfully pulled |
| 8        | Azure    | ****** | fast:2020          | Docker            | FALSE  | user1:{%foo{%12345A                                            |                                                                       |
| 9        | Azure    | ****** | fast:2020          | Docker            | FALSE  | user2:bar{{12345A                                              |                                                                       |
| 10       | Azure    | ****** | fast:2020          | Docker            | FALSE  | user3:{#testuser{#12345A                                       |                                                                       |
| 11       | Azure    | ****** | fast:2020          | Docker            | FALSE  | user4:#mytest##account#12345A                                  |                                                                       |
| 12       | Azure    | ****** | fast:2020          | Docker            | FALSE  | user5:*+?\.^{]$&|Reg1                                          | regex special characters                                              |
| 13       | Azure    | ****** | fast:2020          | Docker            | FALSE  | user6:A1{%a%}{{b}}{#c#}#d##                                    |                                                                       |
| 14       | Azure    | ****** | stable:2023.03 R/S | Docker            | TRUE   | Unmodified                                                     | used cr.sas.com to verified all images were still successfully pulled |

#### Extra Test

**Extra 1.**

For users who are defining `V4_CFG_CR_PASSWORD`/`V4_CFG_CR_USER` directory in their ansible-vars which could container [special Jinja2 characters]((https://jinja.palletsprojects.com/en/2.11.x/templates/#synopsis)), we document in CONFIG-VARS.md that they should mark the variable as "!unsafe" meaning that Ansible will not attempt to template the string and leave it as is. Marking the value as unsafe is something that needs to be done at variable definition time meaning it has to happen inside the ansible-vars.yaml, at the moment it does not seem to be able to be changed/updated after the fact. Documentation for [unsafe keyword](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings)

Example:
```yaml
V4_CFG_CR_PASSWORD: !unsafe "my{%crpassword"
```

For this test I will define an unsafe V4_CFG_CR_PASSWORD and ensure that the cr_access.json file correctly gets created and that the image pull secret is able to be successfully used in the cluster.

| Scenario | Provider | Order  | Cadence   | Deployment Method | DEPLOY | Credentials (created this user in my personal harbor instance) | Notes                                  |
| -------- | -------- | ------ | --------- | ----------------- | ------ | -------------------------------------------------------------- | -------------------------------------- |
| Extra 1  | OSS      | ****** | fast:2020 | Docker            | TRUE   | user6:A1{%a%}{{b}}{#c#}#d##                                    | defined V4_CFG_CR_PASSWORD with unsafe |

