### PR TITLE
fix: (IAC-939) Prevent metrics-server Tasks From Running on Non-AWS Clusters

### DIFF
--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -77,8 +77,11 @@
   tags:
     - baseline
 
+# The metrics-server tasks are only applicable for AWS
 - name: Include metrics-server
   include_tasks: 
     file: metrics-server.yaml
   tags:
     - baseline
+  when:
+    - PROVIDER in ["aws"]

--- a/roles/baseline/tasks/metrics-server.yaml
+++ b/roles/baseline/tasks/metrics-server.yaml
@@ -44,3 +44,5 @@
     wait: true
   tags:
     - uninstall
+  when:
+    - METRICS_SERVER_ENABLED


### PR DESCRIPTION
# WIP