### PR TITLE
fix: (IAC-358) Update uidNumber for test users in example LDAP confs

### DIFF
--- a/examples/multi-tenancy/openldap/openldap-modify-mt-users-groups.yaml
+++ b/examples/multi-tenancy/openldap/openldap-modify-mt-users-groups.yaml
@@ -40,7 +40,7 @@ patch: |-
       objectClass: inetOrgPerson
       objectclass: extensibleObject
       uid: basic_user1
-      uidNumber: 1001
+      uidNumber: 7001
       gidNumber: 1000
       cn: basic_user1
       sn: Tester

--- a/examples/openldap/openldap-modify-users.yaml
+++ b/examples/openldap/openldap-modify-users.yaml
@@ -27,7 +27,7 @@ patch: |-
       objectClass: inetOrgPerson
       objectclass: extensibleObject
       uid: basic_user1
-      uidNumber: 1001
+      uidNumber: 7001
       gidNumber: 1000
       cn: basic_user1
       sn: BasicUser

--- a/roles/vdm/templates/generators/openldap-bootstrap-config.yaml
+++ b/roles/vdm/templates/generators/openldap-bootstrap-config.yaml
@@ -30,7 +30,7 @@ literals:
     objectClass: inetOrgPerson
     objectclass: extensibleObject
     uid: user1
-    uidNumber: 1001
+    uidNumber: 7001
     gidNumber: 1000
     cn: user1
     sn: Tester
@@ -45,7 +45,7 @@ literals:
     objectClass: inetOrgPerson
     objectclass: extensibleObject
     uid: user2
-    uidNumber: 1002
+    uidNumber: 7002
     gidNumber: 1000
     cn: user2
     sn: Tester

--- a/roles/vdm/templates/generators/openldap-bootstrap-mt-config.yaml
+++ b/roles/vdm/templates/generators/openldap-bootstrap-mt-config.yaml
@@ -36,7 +36,7 @@ literals:
     objectClass: inetOrgPerson
     objectclass: extensibleObject
     uid: user1
-    uidNumber: 1001
+    uidNumber: 7001
     gidNumber: 1000
     cn: user1
     sn: Tester
@@ -51,7 +51,7 @@ literals:
     objectClass: inetOrgPerson
     objectclass: extensibleObject
     uid: user2
-    uidNumber: 1002
+    uidNumber: 7002
     gidNumber: 1000
     cn: user2
     sn: Tester


### PR DESCRIPTION
### Changes

In our example OpenLDAP configuration files, one of the test users has the uidNumber of 1001.

From the SAS Documentation:

> Some pods run system-critical processes under the UID 1001. This UID acts as the owner of CAS server sessions by default and cannot be changed, with one exception: the OpenSearch pods have an option to change the run user. Verify that no user accounts in your LDAP directory are using this UID. This run user is comparable to the sas user account in previous versions of SAS, but it does not exist outside of the container where it runs.
https://go.documentation.sas.com/doc/en/itopscdc/v_038/itopssr/n0bqwd5t5y2va7n1u9xb57lfa9wx.htm#p1l9afrs6ykfjyn1xp09ohsyx392


The PR changes the user1 uidNumber to 7001, I also updated user2 that's in the same group to 7002 to keep it sequential.

### Tests

Ran through the following scenarios and verified LDAP contents and ability to log into Viya 

| Scenario | Provider | K8s Version      | Order  | Cadence   | multi-tenant | Summary                                                                                                                   |
|:---------|:---------|:-----------------|:-------|:----------|:-------------|:--------------------------------------------------------------------------------------------------------------------------|
| 1        | GCP      | v1.24.12-gke.500 | * | fast:2020 | FALSE        | default openldap-bootstrap-config.yaml used                                                                               |
| 2        | GCP      | v1.24.12-gke.500 | * | fast:2020 | FALSE        | put openldap-modify-users.yaml in site-config                                                                             |
| 3        | GCP      | v1.24.12-gke.500 | * | fast:2020 | TRUE         | Used openldap-modify-mt-users-groups.yaml                                                                                 |
| 4        | GCP      | v1.24.12-gke.500 | * | fast:2020 | FALSE        | initially deployed with 6.4.0's openldap-modify-users.yaml -> reinstalled viya with PR openldap-modify-users.yaml changes |
