### PR TITLE
feat: (IAC-298) Security update - `use-forwarded-headers` set to false for ingress-ngnix

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -8,7 +8,7 @@
   - [kustomize - Generate deployment manifest](#kustomize---generate-deployment-manifest)
   - [Ingress-Nginx issue - Unable to access SAS Viya Platform web apps](#ingress-nginx-issue---unable-to-access-sas-viya-platform-web-apps)
   - [Ansible Variables with Special Jinja2 Characters](#ansible-variables-with-special-jinja2-characters)
-
+  - [Ingress-Nginx - use-forwarded-headers disabled](#ingress-nginx---use-forwarded-headers-disabled)
 
 ## Debug Mode
 Debug mode can be enabled by adding "-vvv" to the end of the docker or ansible commands
@@ -31,6 +31,7 @@ Example:
     -e TFSTATE=$HOME/viya4-iac-aws/terraform.tfstate \
     viya4-deployment --tags "baseline,viya,cluster-logging,cluster-monitoring,viya-monitoring,install" -vvv
   ```
+
 ## Viya4 Monitoring and Logging
 ### Symptom:
 While deploying the SAS Viya platform to a cluster with the "cluster-logging" and "install" Ansible task tags specified, the following error message is encountered.
@@ -149,7 +150,6 @@ Note: If you used viya4-iac-aws:5.6.0 or newer to create your infrastructure, th
       kubectl scale --replicas=1 deployment/cluster-autoscaler-aws-cluster-autoscaler
       ```
 
-
 ## kustomize - Generate deployment manifest
 
 ### Symptom:
@@ -260,3 +260,26 @@ V4_CFG_CR_PASSWORD: !unsafe "A1{%a%}{{b}}{#c#}#d##"
 ```
 
 For additional information about the `!unsafe` keyword see the [Ansible Advanced playbook syntax documentation](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings)
+
+## Ingress-Nginx - use-forwarded-headers disabled
+### Symptom:
+In viya4-deployment v6.4.0 or before the default value for `use-forwarded-headers` was set to true. This has raised a security concern and needs to be updated.
+
+### Diagnosis:
+
+The document [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers) states the use of `use-forwarded-headers` as follows:
+
+>If true, NGINX passes the incoming X-Forwarded-* headers to upstream. Use this option when NGINX is behind another L7 proxy / load balancer that is setting these headers.
+>
+>If false, NGINX ignores incoming X-Forwarded-* headers, filling them with the request information it sees. Use this option if NGINX is exposed directly to the internet, or it's behind a L3/packet-based load balancer that doesn't alter the source IP in the packets.
+
+### Solution:
+
+As NGINX is not behind another L7 proxy / load balancer we are setting the `use-forwarded-headers` to false by default starting viya4-deployment v6.5.0 or later. If you wish to enable the incoming X-Forwarded headers then please add the following in your ansible-vars.yaml file.
+
+```bash
+INGRESS_NGINX_CONFIG:
+  controller:
+    config:
+      use-forwarded-headers: "true"
+```

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -56,7 +56,7 @@ INGRESS_NGINX_CONFIG:
       annotations:
 
     config:
-      use-forwarded-headers: "true"
+      use-forwarded-headers: "false"
       hsts-max-age: "63072000"
     tcp: {}
     udp: {}
@@ -86,7 +86,7 @@ INGRESS_NGINX_CVE_2021_25742_PATCH:
     config:
       allow-snippet-annotations: "true"
       large-client-header-buffers: "4 32k"
-      use-forwarded-headers: "true"
+      use-forwarded-headers: "false"
       annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
 
 ## Nfs-subdir-external-provisioner

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -54,7 +54,6 @@ INGRESS_NGINX_CONFIG:
       sessionAffinity: None
       loadBalancerSourceRanges: "{{ LOADBALANCER_SOURCE_RANGES |default(['0.0.0.0/0'], -1) }}"
       annotations:
-
     config:
       use-forwarded-headers: "false"
       hsts-max-age: "63072000"
@@ -86,7 +85,6 @@ INGRESS_NGINX_CVE_2021_25742_PATCH:
     config:
       allow-snippet-annotations: "true"
       large-client-header-buffers: "4 32k"
-      use-forwarded-headers: "false"
       annotation-value-word-blocklist: "load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},\\"
 
 ## Nfs-subdir-external-provisioner


### PR DESCRIPTION
# Changes:
Previously the default value for `use-forwarded-headers` was set to true. This has raised a security concern as it allows spoofing source IP via X-Forwarded-For header.

[NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers) states the use of `use-forwarded-headers` as follows:

>If true, NGINX passes the incoming X-Forwarded-* headers to upstream. Use this option when NGINX is behind another L7 proxy / load balancer that is setting these headers.
>
>If false, NGINX ignores incoming X-Forwarded-* headers, filling them with the request information it sees. Use this option if NGINX is exposed directly to the internet, or it's behind a L3/packet-based load balancer that doesn't alter the source IP in the packets.

As NGINX is not behind another L7 proxy / load balancer this PR will set the `use-forwarded-headers` to false by default. Instructions are added in troubleshooting guide if user wishes to enable this setting.

# Tests: 
Verified on following scenarios, the deployment stabilized and applications were accessible using the change `use-forwarded-headers = false`. See additional details and tests in internal ticket:
|Scenario|Task|Provider|Cadence|
|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|
|2|OOTB|AWS|fast:2020|
|3|OOTB|GCP|fast:2020|