### PR TITLE
feat: (IAC-1002) Upgrade the default ingress-nginx and kubectl versions to work with K8s 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.24.10
+ARG kubectl_version=1.25.8
 
 WORKDIR /build
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -395,7 +395,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 3.40.0 is used for Kubernetes clusters whose version is <= 1.21.X, and version 4.3.0 is used for Kubernetes clusters whose version is >= 1.22.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.23.X, and version 4.6.0 is used for Kubernetes clusters whose version is >= 1.24.X. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -42,7 +42,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.24.10 \
+	--build-arg kubectl_version=1.25.8 \
 	-t viya4-deployment .
 ```
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | docker           | >=20.10.10  |
 | ~              | git              | any         |
 | ~              | rsync            | any         |
-| ~              | kubectl          | 1.22 - 1.24 |
+| ~              | kubectl          | 1.24 - 1.26 |
 | ~              | Helm             | 3           |
 | pip3           | ansible          | 2.10.7      |
 | pip3           | openshift        | 0.12.0      |

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -31,15 +31,15 @@ METRICS_SERVER_CONFIG:
 ## Ingress-nginx - Defaults
 ingressVersions:
   k8sMinorVersionCeiling:
-    value: 21
-    api:
-      chartVersion: 3.40.0
-      appVersion: 0.50.0
-  k8sMinorVersionFloor:
-    value: 22
+    value: 23
     api:
       chartVersion: 4.3.0
       appVersion: 1.4.0
+  k8sMinorVersionFloor:
+    value: 24
+    api:
+      chartVersion: 4.6.0
+      appVersion: 1.7.0
 
 ## Ingress-nginx - Ingress
 INGRESS_NGINX_NAME: ingress-nginx


### PR DESCRIPTION
# Changes:
SAS Viya Platform is going to support a range of K8s `1.24-1.26` in cadence `v2023.05`. This PR contains following updates:
- The default kubectl version updated to `1.25.8`
- The default ingress-nginx version updated:
  - For K8s version `>= 1.24.X` the default ingress-nginx version is updated to the latest app version: `1.7.0` or chart version: `4.6.0`.
  - For K8s version `<= 1.23.X` the default ingress-nginx version is updated to the latest app version: `1.4.0` or chart version: `4.3.0`. **Note**: This is same version from previous release.


# Tests:
Verified SAS Viya Platform deployment is successful on the following scenarios, see details in internal ticket:

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|
|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.25|ansible, DO: true|
|2|OOTB|Azure|fast:2020|1.26|ansible, DO: true|
|3|OOTB|Azure|Stable 2023.04|1.24|docker, DO: false|
|4|OOTB|AWS|Stable 2023.04|1.23|docker, DO: true|