### PR TITLE
fix: (IAC-751) Some technology and version information are being leaked in header response

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -58,6 +58,7 @@ INGRESS_NGINX_CONFIG:
     config:
       use-forwarded-headers: "true"
       hsts-max-age: "63072000"
+      hide-headers: "Server,X-Powered-By"
     tcp: {}
     udp: {}
     lifecycle:


### PR DESCRIPTION
Security testing with OWASP Zap found that pods were responding with header information identifying both `Server` and `X-Powered-By` information.

This code will eliminate this when the ingress-controller is installed.