### PR TITLE
feat: (IAC-696) DAC - Install gke-gcloud-auth-plugin with viya4-deployment for K8s v1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 FROM baseline
 ARG helm_version=3.9.4
 ARG aws_cli_version=2.7.22
-ARG gcp_cli_version=427.0.0-0
+ARG gcp_cli_version=428.0.0-0
 
 # Add extra packages
 RUN apt-get install -y gzip wget git git-lfs jq sshpass skopeo rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker/dockerfile:experimental
 FROM ubuntu:22.04 as baseline
-RUN apt update && apt upgrade -y \
-  && apt install -y python3 python3-dev python3-pip curl unzip \
+
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y python3 python3-dev python3-pip curl unzip apt-transport-https ca-certificates gnupg \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.24.10
+ARG kubectl_version=1.25.8
 
 WORKDIR /build
 
@@ -16,10 +17,10 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 FROM baseline
 ARG helm_version=3.9.4
 ARG aws_cli_version=2.7.22
-ARG gcp_cli_version=409.0.0
+ARG gcp_cli_version=427.0.0-0
 
 # Add extra packages
-RUN apt install -y gzip wget git git-lfs jq sshpass skopeo rsync \
+RUN apt-get install -y gzip wget git git-lfs jq sshpass skopeo rsync \
   && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
   && ./get-helm-3 --version v$helm_version --no-sudo \
   && helm plugin install https://github.com/databus23/helm-diff \
@@ -30,9 +31,10 @@ RUN apt install -y gzip wget git git-lfs jq sshpass skopeo rsync \
   # AZURE
   && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
   # GCP
-  && curl "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${gcp_cli_version}-linux-x86_64.tar.gz" -o gcpcli.tar.gz \
-  && tar -xvf gcpcli.tar.gz \
-  && ./google-cloud-sdk/install.sh
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+  && apt-get update && apt-get install google-cloud-cli:amd64=${gcp_cli_version} \
+  && apt-get install google-cloud-sdk-gke-gcloud-auth-plugin 
 
 COPY --from=tool_builder /build/kubectl /usr/local/bin/kubectl
 
@@ -50,7 +52,6 @@ RUN pip install -r ./requirements.txt \
 ENV PLAYBOOK=playbook.yaml
 ENV VIYA4_DEPLOYMENT_TOOLING=docker
 ENV ANSIBLE_CONFIG=/viya4-deployment/ansible.cfg
-ENV PATH=$PATH:/google-cloud-sdk/bin/
 
 VOLUME ["/data", "/config", "/vault"]
 ENTRYPOINT ["/viya4-deployment/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The value is the path to a standard SAS Viya platform sitedefault file. If none 
 
 The Kubernetes access configuration file. If you used one of the SAS Viya 4 IaC projects to provision your cluster, this value is not required.
 
+If you used the [viya4-iac-gcp](https://github.com/sassoftware/viya4-iac-gcp) project to create a provider based kubeconfig file to access your GKE cluster, refer to [kubernetes configuration file types](./docs/user/Kubeconfig.md) for instructions on using a GCP provider based kubeconfig file with the viya4-deployment project.
+
 #### Terraform State File
 
 If you used a SAS Viya 4 IaC project to provision your cluster, you can provide the resulting tfstate file to have the kubeconfig and other settings auto-discovered. The [ansible-vars-iac.yaml](examples/ansible-vars-iac.yaml) example file shows the values that must be set when using the SAS Viya 4 IaC integration.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,5 +23,7 @@ do
   fi
 done
 
+# TODO: Can remove the next line when DAC moves to kubectl >= 1.26
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 echo  "Running: ansible-playbook $OPTS $@ playbooks/${PLAYBOOK}"
 ANSIBLE_STDOUT_CALLBACK=yaml exec ansible-playbook $OPTS $@ playbooks/${PLAYBOOK}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ do
   fi
 done
 
-# TODO: Can remove the next line when DAC moves to kubectl >= 1.26
+# TODO: Can remove the next line when the default GKE kubernetes_version is moved to 1.26 and greater
 export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 echo  "Running: ansible-playbook $OPTS $@ playbooks/${PLAYBOOK}"
 ANSIBLE_STDOUT_CALLBACK=yaml exec ansible-playbook $OPTS $@ playbooks/${PLAYBOOK}

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -28,7 +28,7 @@ If you are using a provider based kubeconfig file created by viya4-iac-gcp:4.5.0
 | SOURCE         | NAME                    | VERSION     |
 |----------------|-------------------------|-------------|
 | ~              | gcloud                  | 428.0.0     |
-| ~              | gcloud-gke-auth-plugin  | 428.0.0     |
+| ~              | gcloud-gke-auth-plugin  | >= 0.5.2    |
 
 Required project dependencies are generally pinned to known working or stable versions to ensure users have a smooth initial experience. In some cases it may be required to change the default version of a dependency. In such cases users are welcome to experiment with alternate versions, however compatibility may not be guaranteed.
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -24,6 +24,12 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ansible-galaxy | ansible.utils    | 2.3.0       |
 | ansible-galaxy | kubernetes.core  | 2.3.2       |
 
+If you are using a provider based kubeconfig file created by viya4-iac-gcp:4.5.0 or newer, install these dependencies:
+| SOURCE         | NAME                    | VERSION     |
+|----------------|-------------------------|-------------|
+| ~              | gcloud                  | 428.0.0     |
+| ~              | gcloud-gke-auth-plugin  | 428.0.0     |
+
 Required project dependencies are generally pinned to known working or stable versions to ensure users have a smooth initial experience. In some cases it may be required to change the default version of a dependency. In such cases users are welcome to experiment with alternate versions, however compatibility may not be guaranteed.
 
 # Docker

--- a/docs/user/Kubeconfig.md
+++ b/docs/user/Kubeconfig.md
@@ -4,43 +4,45 @@
 
 ### Notes - viya4-deployment:6.6.0
 
-The release of kubectl v1.26 is dropping support for built-in provider-specific code in their project for authentication and instead opting for a plugin-based strategy. To quote this [Google blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke):
+The release of kubectl v1.26 is dropping support for built-in provider-specific code in their project for authentication and instead opting for a plugin-based strategy. A quote from the [Google blog](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) provides an explanation for this change:
 
 >To ensure the separation between the open source version of Kubernetes and those versions that are customized by services providers like Google, the open source community is requiring that all provider-specific code that currently exists in the OSS code base be removed starting with v1.26.
 
-### Usage with viya4-iac-gcp:4.5.0
+### Usage with provider based kubeconfig files from viya4-iac-gcp:4.5.0
 
-Two types of Kubernetes configuration files can be created with the viay4-iac-gcp project:
+Two types of Kubernetes configuration files can be created with the [viya4-iac-gcp](https://github.com/sassoftware/viya4-iac-gcp) project:
 
 - Provider Based
 - Kubernetes Service Account and Cluster Role Binding
 
-For GKE clusters, the provider based kubernetes configuration file format will change to support the use of the `gke-gcloud-auth-plugin`. The `gke-gcloud-auth-plugin` binary is required to access any GKE clusters when using kubectl 1.26+ with a "provider based" kubernetes configuration file. For use with the viya4-deployemnt project, the "service account and cluster role binding" kubernetes configuration file variant remains the same and does not require either `gcloud` or the `gke-gcloud-auth-plugin` binary to communicate with the cluster.
+Starting with viya4-iac-gcp:4.5.0, the provider based kubernetes configuration file format will change to support use of the `gke-gcloud-auth-plugin`. The `gke-gcloud-auth-plugin` binary is required to access any GKE clusters when using kubectl 1.26+ with a "provider based" kubernetes configuration file. When used with the viya4-deployment project, the "service account and cluster role binding" kubernetes configuration file variant remains the same and does not require either `gcloud` or the `gke-gcloud-auth-plugin` binary to communicate with the cluster.
 
-The viya4-deployment Dockerfile includes steps to ensure that the plugin is installed and enabled. If you opt not to use this project via a Docker container produced with the included Dockerfile, you will need to take steps to install both `gcloud` and `gke-gcloud-auth-plugin` on your machine. Google has provided step-by-step instructions in a blog post to aid users with this transition. See [Google's Authentication Blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke).
+The viya4-deployment Dockerfile includes steps to ensure that the `gke-gcloud-auth-plugin` is installed and enabled for use with provider based kubeconfig files. If you opt to [use the Ansible CLI](./AnsibleUsage.md) with this project instead of a Docker container produced with the included Dockerfile, and you are using a provider based kubeconfig file, you will need to take steps to install both `gcloud` and the `gke-gcloud-auth-plugin` on your machine. Google has provided step-by-step instructions in a blog post to aid users with this transition. See [Google's Authentication Blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke).
 
 See the [viya4-iac-gcp Kubeconfig document](https://github.com/sassoftware/viya4-iac-gcp/blob/main/docs/user/Kubeconfig.md) for more details on creating both types of GKE Kubernetes Configuration files.
 
 ### Examples
 
-- I have opted to use this project via a Docker container produced with the provided Dockerfile. I have a provider based Kubernetes Configuration File and I want to baseline and deploy Viya only.
+Using the viya4-deployment project with a viya4-iac-gcp created provider based kubeconfig file requires providing values for the V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME and a V4_CLOUD_SERVICE_ACCOUNT_AUTH file. Refer to the section below for examples of how to express those two values with either the docker container or ansible CLI usage patterns.
+
+- I have opted to use this project via a Docker container produced with the provided Dockerfile. I have a provider based Kubernetes configuration file and I want to baseline and deploy Viya only.
 
   ```bash
   docker run --rm --group-add root --user "$(id -u):$(id -g)" --volume "$HOME"/deployments:/data \
   --volume $HOME/deployments/dev-cluster/dev-namespace/ansible-vars-iac-gcp.yaml:/config/config \
   --volume $HOME/terraform.tfstate:/config/tfstate \
   --volume $HOME/.ssh/id_rsa:/config/jump_svr_private_key \
-  --volume $HOME/public/davhou-696f-gke-kubeconfig-client.conf:/config/kubeconfig \
+  --volume $HOME/public/prefix-gke-kubeconfig.conf:/config/kubeconfig \
   --volume $HOME/credentials/.gcp-service-account.json:/config/v4_cfg_cloud_service_account_auth \
   viya4-deployment --tags "baseline,viya,install" -v -e V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME=proj-terraform@project.iam.gserviceaccount.com
   ```
 
-- I have opted not to use this project via a Docker container produced with the provided Dockerfile. I have followed the steps linked above to install both `gcloud` and the `gke-gcloud-auth-plugin`. I have a provider based Kubernetes Configuration File and I want to baseline and deploy Viya only.
+- I have opted to use this project with the ansible CLI and have followed the linked steps above to install both `gcloud` and the `gke-gcloud-auth-plugin`. I have a provider based Kubernetes configuration file and I want to baseline and deploy Viya only.
 
   ```bash
   ansible-playbook \
     -e V4M_VERSION=stable -e BASE_DIR=$HOME/deployments \
-    -e KUBECONFIG=$HOME/deployments/dev-cluster/dev-namespace/prefix-gke-kubeconfig-client.conf \
+    -e KUBECONFIG=$HOME/deployments/dev-cluster/dev-namespace/prefix-gke-kubeconfig.conf \
     -e CONFIG=$HOME/deployments/dev-cluster/dev-namespace/ansible-vars-iac-gcp.yaml \
     -e TFSTATE=$HOME/deployments/dev-cluster/dev-namespace/terraform.tfstate \
     -e JUMP_SVR_PRIVATE_KEY=$HOME/.ssh/id_rsa \

--- a/docs/user/Kubeconfig.md
+++ b/docs/user/Kubeconfig.md
@@ -1,0 +1,50 @@
+# Kubernetes Configuration File Types
+
+## Overview
+
+### Notes - viya4-deployment:6.6.0
+
+The release of kubectl v1.26 is dropping support for built-in provider-specific code in their project for authentication and instead opting for a plugin-based strategy. To quote this [Google blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke):
+
+>To ensure the separation between the open source version of Kubernetes and those versions that are customized by services providers like Google, the open source community is requiring that all provider-specific code that currently exists in the OSS code base be removed starting with v1.26.
+
+### Usage with viya4-iac-gcp:4.5.0
+
+Two types of Kubernetes configuration files can be created with the viay4-iac-gcp project:
+
+- Provider Based
+- Kubernetes Service Account and Cluster Role Binding
+
+For GKE clusters, the provider based kubernetes configuration file format will change to support the use of the `gke-gcloud-auth-plugin`. The `gke-gcloud-auth-plugin` binary is required to access any GKE clusters when using kubectl 1.26+ with a "provider based" kubernetes configuration file. For use with the viya4-deployemnt project, the "service account and cluster role binding" kubernetes configuration file variant remains the same and does not require either `gcloud` or the `gke-gcloud-auth-plugin` binary to communicate with the cluster.
+
+The viya4-deployment Dockerfile includes steps to ensure that the plugin is installed and enabled. If you opt not to use this project via a Docker container produced with the included Dockerfile, you will need to take steps to install both `gcloud` and `gke-gcloud-auth-plugin` on your machine. Google has provided step-by-step instructions in a blog post to aid users with this transition. See [Google's Authentication Blog post](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke).
+
+See the [viya4-iac-gcp Kubeconfig document](https://github.com/sassoftware/viya4-iac-gcp/blob/main/docs/user/Kubeconfig.md) for more details on creating both types of GKE Kubernetes Configuration files.
+
+### Examples
+
+- I have opted to use this project via a Docker container produced with the provided Dockerfile. I have a provider based Kubernetes Configuration File and I want to baseline and deploy Viya only.
+
+  ```bash
+  docker run --rm --group-add root --user "$(id -u):$(id -g)" --volume "$HOME"/deployments:/data \
+  --volume $HOME/deployments/dev-cluster/dev-namespace/ansible-vars-iac-gcp.yaml:/config/config \
+  --volume $HOME/terraform.tfstate:/config/tfstate \
+  --volume $HOME/.ssh/id_rsa:/config/jump_svr_private_key \
+  --volume $HOME/public/davhou-696f-gke-kubeconfig-client.conf:/config/kubeconfig \
+  --volume $HOME/credentials/.gcp-service-account.json:/config/v4_cfg_cloud_service_account_auth \
+  viya4-deployment --tags "baseline,viya,install" -v -e V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME=proj-terraform@project.iam.gserviceaccount.com
+  ```
+
+- I have opted not to use this project via a Docker container produced with the provided Dockerfile. I have followed the steps linked above to install both `gcloud` and the `gke-gcloud-auth-plugin`. I have a provider based Kubernetes Configuration File and I want to baseline and deploy Viya only.
+
+  ```bash
+  ansible-playbook \
+    -e V4M_VERSION=stable -e BASE_DIR=$HOME/deployments \
+    -e KUBECONFIG=$HOME/deployments/dev-cluster/dev-namespace/prefix-gke-kubeconfig-client.conf \
+    -e CONFIG=$HOME/deployments/dev-cluster/dev-namespace/ansible-vars-iac-gcp.yaml \
+    -e TFSTATE=$HOME/deployments/dev-cluster/dev-namespace/terraform.tfstate \
+    -e JUMP_SVR_PRIVATE_KEY=$HOME/.ssh/id_rsa \
+    -e V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME=proj-terraform@project.iam.gserviceaccount.com \
+    -e V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH=$HOME/creds/.gcp-service-account.json \
+    playbooks/playbook.yaml --tags "baseline,viya,install" -v
+```

--- a/docs/user/Kubeconfig.md
+++ b/docs/user/Kubeconfig.md
@@ -23,7 +23,7 @@ See the [viya4-iac-gcp Kubeconfig document](https://github.com/sassoftware/viya4
 
 ### Examples
 
-Using the viya4-deployment project with a viya4-iac-gcp created provider based kubeconfig file requires providing values for the V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME and a V4_CLOUD_SERVICE_ACCOUNT_AUTH file. Refer to the section below for examples of how to express those two values with either the docker container or ansible CLI usage patterns.
+Using the viya4-deployment project with a viya4-iac-gcp "provider based" kubeconfig file requires providing values for the V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME and a V4_CLOUD_SERVICE_ACCOUNT_AUTH file. Refer to the section below for examples of how to express those two values with either the docker container or ansible CLI usage patterns.
 
 - I have opted to use this project via a Docker container produced with the provided Dockerfile. I have a provider based Kubernetes configuration file and I want to baseline and deploy Viya only.
 

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -3,6 +3,16 @@
 
 
 ---
+- name: baseline - gcloud auth for client-go kubeconfig
+  shell: |
+    gcloud auth activate-service-account '{{ V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME }}' --key-file={{ V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH }}
+  when:
+    - V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME is defined
+    - V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH is defined
+    - PROVIDER == "gcp"
+  tags:
+    - baseline
+
 - name: Include nfs-subdir-external-provisioner
   include_tasks: 
     file: nfs-subdir-external-provisioner.yaml

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -3,16 +3,6 @@
 
 
 ---
-- name: baseline - gcloud auth for client-go kubeconfig
-  shell: |
-    gcloud auth activate-service-account '{{ V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME }}' --key-file={{ V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH }}
-  when:
-    - V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME is defined
-    - V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH is defined
-    - PROVIDER == "gcp"
-  tags:
-    - baseline
-
 - name: Include nfs-subdir-external-provisioner
   include_tasks: 
     file: nfs-subdir-external-provisioner.yaml

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -263,6 +263,29 @@
     - cas-onboard
     - offboard
 
+- name: Set env_path
+  set_fact:
+    env_path: "{{ lookup('env', 'PATH') |default('', True) }}"
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: baseline - gcloud auth use service account
+  shell: |
+    gcloud auth activate-service-account '{{ V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME }}' --key-file={{ V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH }}
+  when:
+    - V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME is defined
+    - V4_CFG_CLOUD_SERVICE_ACCOUNT_AUTH is defined
+    - PROVIDER == "gcp"
+  tags:
+    - install
+    - uninstall
+    - update
+    - onboard
+    - cas-onboard
+    - offboard
+
 - name: Set V4_CFG_MANAGE_STORAGE default
   block:
     - name: Set V4_CFG_MANAGE_STORAGE default

--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -44,7 +44,7 @@
         state: directory
     - name: deploy - Deploy SAS Viya
       environment:
-        PATH: "{{ ORCHESTRATION_TOOLING_PATH }}"
+        PATH: "{{ env_path + ':' + ORCHESTRATION_TOOLING_PATH }}"
         KUBECONFIG: "{{ KUBECONFIG }}"
         WORK_DIRECTORY: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work"
       command: |


### PR DESCRIPTION
# Changes
Existing versions of kubectl and custom Kubernetes clients contain provider-specific code to manage authentication between the client and Google Kubernetes Engine. Starting with v1.26, that authentication code will no longer be included as part of the OSS kubectl. The `gke-gcloud-auth-plugin` will fill the gap for the authentication code that is being removed from kubectl.

viya4-deployment supports using two types of GKE kubernetes configuration files, also known as kubeconfig files. The `gke-gcloud-auth-plugin` binary is required to access a GKE clusters when using kubectl 1.26+ with a "provider based" kubernetes configuration file. The "service account and cluster role binding" kubernetes configuration file variant remains the same and still does not require either `gcloud` or the `gke-gcloud-auth-plugin` binary to communicate with the cluster.
The `gke-gcloud-auth-plugin` binary will now be installed as part of the viya4-deployment docker container and is available to the `gcloud` and kubectl binaries within the container.
If a viya4-deployment user has chosen to use a provider based kubernetes configuration file and runs viya4-deployment via Ansible, they will need to install the `gcloud` binary and `gke-gcloud-auth-plugin` using the documented instructions.
See doc here: https://github.com/sassoftware/viya4-deployment/pull/435/files#diff-8a22ddc8bcdf8b5b392d4e76e637e4e6fd79cba9ebf343dddef54713b947a293R20

### Related viya4-iac-gcp changes
Updates in the [PR](https://github.com/sassoftware/viya4-iac-gcp/pull/169) for viya4-iac-gcp have been made to how the Provider based kubernetes configuration file is generated. The format has been updated to support the use of the `gke-gcloud-auth-plugin`. The `gke-gcloud-auth-plugin` allows client authentication to 1.26 GKE clusters with provider based kubernetes configuration files since provider specific authentication code will not be included with OSS kubectl any longer.

# Tests
|Scenario | Task | Deployment method | Task tags | Security | KUBECONFIG |V4_CFG_CLOUD_SERVICE_ACCOUNT_NAME | gcloud version | gke-gcloud-auth-plugin | kubectl version | k8s version | Orchestration | Provider | Cadence | INGRESS_NGINX_CHART_VERSION |Notes
|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|
1 | OOTB | docker | baseline,viya,install | front door TLS | non-static kubeconfig (auth-plugin) |sa_name@project_name.iam.gserviceaccount.com | 427.0.0 | 0.5.2 (reported from gcloud version ) | 1.25.8 | 1.26.3 | deploy | GCP | Fast | 4.5.2
2 |  OOTB | docker | baseline,viya,install | same as above | static kubeconfig | n/a | 428.0.0 | 0.5.2 | 1.25.8 | 1.26.3 | deploy | GCP | Fast | 4.5.2
3 |  OOTB | ansible | baseline,viya,install | front door TLS | non-static kubeconfig (auth-plugin) | sa_name@project_name.iam.gserviceaccount.com | 427.0.0 | 0.5.2 | 1.25.5 | 1.26.3 | deploy | GCP | Fast | 4.5.2 | Ansible deployment method with non-static kubeconfig is not supported 
4 | OOTB | ansible | baseline,viya,install | same as above | static kubeconfig | n/a | 428.0.0 | 0.5.2 | 1.25.8 | 1.26.3 | deploy | GCP | Fast | 4.5.2
5 | OOTB | docker | viya, install | front door TLS | non-static kubeconfig (auth-plugin) | sa_name@project_name.iam.gserviceaccount.com | 428.0.0 | 0.5.2 | 1.25.8 | 1.26.3 | DO | GCP | Fast | 4.5.2
6 | logging/ monitoring | docker | baseline,cluster-logging,cluster-monitoring,viya,install | front door TLS | non-static kubeconfig (auth-plugin) | sa_name@project_name.iam.gserviceaccount.com | 428.0.0 | 0.5.2 | 1.25.8 | 1.26.3 | deploy | GCP | Fast | 4.6.0
7 | OOTB 1.25 cluster | docker | baseline,viya,install | front door TLS | static kubeconfig | n/a | 428.0.0 | 0.5.2 | 1.25.8 | 1.25.8-gke | deploy | GCP | stable:2023.04 | 4.6.0
8 | OOTB 1.24 cluster | docker | baseline,viya,install | front door TLS | static kubeconfig | n/a | 428.0.0 | 0.5.2 | 1.25.8 | 1.24.12-gke.1000 | DO | GCP | stable:2023.04 | 4.6.0
