### PR TITLE
fix: (IAC-999) Remediate critical security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@
 FROM ubuntu:22.04 as baseline
 
 RUN apt-get update && apt-get upgrade -y \
-  && apt-get install -y python3 python3-dev python3-pip curl unzip apt-transport-https ca-certificates gnupg \
+  && apt-get install --no-install-recommends -y python3 python3-dev python3-pip curl unzip apt-transport-https ca-certificates gnupg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.25.8
+ARG kubectl_version=1.25.9
 
 WORKDIR /build
 
@@ -15,15 +17,15 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 
 # Installation
 FROM baseline
-ARG helm_version=3.9.4
+ARG helm_version=3.11.3
 ARG aws_cli_version=2.7.22
 ARG gcp_cli_version=428.0.0-0
 
 # Add extra packages
-RUN apt-get install -y gzip wget git git-lfs jq sshpass skopeo rsync \
+RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass skopeo rsync \
+  && rm -f /etc/ssh/ssh_host_rsa_key && rm -f /etc/ssh/ssh_host_ecdsa_key && rm -f /etc/ssh/ssh_host_ed25519_key \
   && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
   && ./get-helm-3 --version v$helm_version --no-sudo \
-  && helm plugin install https://github.com/databus23/helm-diff \
   # AWS
   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${aws_cli_version}.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
@@ -33,8 +35,10 @@ RUN apt-get install -y gzip wget git git-lfs jq sshpass skopeo rsync \
   # GCP
   && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
-  && apt-get update && apt-get install google-cloud-cli:amd64=${gcp_cli_version} \
-  && apt-get install google-cloud-sdk-gke-gcloud-auth-plugin 
+  && apt-get update && apt-get install --no-install-recommends -y google-cloud-cli:amd64=${gcp_cli_version} \
+  && apt-get install --no-install-recommends -y google-cloud-sdk-gke-gcloud-auth-plugin \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tool_builder /build/kubectl /usr/local/bin/kubectl
 
@@ -45,6 +49,9 @@ ENV HOME=/viya4-deployment
 
 RUN pip install -r ./requirements.txt \
   && ansible-galaxy install -r ./requirements.yaml \
+  && rm -rf /usr/local/lib/python3.10/dist-packages/ansible_collections/infinidat \
+  && rm -rf /usr/local/lib/python3.10/dist-packages/ansible_collections/netbox \
+  && pip cache purge \
   && chmod -R g=u /etc/passwd /etc/group /viya4-deployment/ \
   && chmod 755 /viya4-deployment/docker-entrypoint.sh \
   && git config --system --add safe.directory /viya4-deployment

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -48,7 +48,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.25.8 \
+	--build-arg kubectl_version=1.25.9 \
 	-t viya4-deployment .
 ```
 


### PR DESCRIPTION
# Changes
Updates required to remediate critical security vulnerabilities

- move kubectl to version 1.25.9 to remediate critical CVE
- move helm to version 3.11.3 to remediate critical CVE
- removed vulnerable and unused binaries git-lfs and helm-diff
- Use apt-get clean and remove apt lists/* on RUN commands to trim image size
- Use pip cache purge following pip install to trim image size
- qualify apt-get install commands with --no-install-recommends to prevent unwanted/unknown installs
- remove unused infinidat and netbox ansible collections to remediate critical CVEs
- removed ssh host keys in /etc/ssh flagged as sensitive data

# Tests
Aqua scan of docker image built using the changes below was marked compliant with no Critical CVEs or sensitive data present.

|Scenario|Task|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|
|1|OOTB|Azure|1.25.6|fast:2020|baseline,cluster-logging,cluster-monitoring,viya,install|deploy command| Deployment command completed successfully and pods stabilized. Successful login to Viya as viya_admin.|
|2|OOTB|AWS|1.25.9-eks|fast:2020|baseline,cluster-logging,viya,install|deploy command|Deployment command completed successfully and pods stabilized. Successful login to Viya as viya_admin.|
|3|OOTB|AWS|1.25.9-eks|fast:2020|baseline,viya,install|DO|DO Deployment completed successfully and pods stabilized. Successful login to Viya as viya_admin.|