### PR TITLE
fix: (IAC-994) Add K8S Cluster name to dynamic volumes created by EBS CSI Driver

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -186,6 +186,7 @@ EBS_CSI_DRIVER_ACCOUNT: null
 EBS_CSI_DRIVER_LOCATION: us-east-1
 EBS_CSI_DRIVER_CONFIG:
   controller:
+    k8sTagClusterId: "{{ CLUSTER_NAME }}"
     region: "{{ EBS_CSI_DRIVER_LOCATION }}"
     serviceAccount:
       create: true

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -13,7 +13,7 @@ CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
 CERT_MANAGER_CHART_VERSION: 1.11.0
-CERT_MANAGER_CONFIG: 
+CERT_MANAGER_CONFIG:
   installCRDs: "true"
   extraArgs:
     - --enable-certificate-owner-ref=true
@@ -55,7 +55,7 @@ INGRESS_NGINX_CHART_URL: https://kubernetes.github.io/ingress-nginx
 INGRESS_NGINX_CHART_VERSION: ""
 INGRESS_NGINX_CONFIG:
   controller:
-    service: 
+    service:
       externalTrafficPolicy: Local
       sessionAffinity: None
       loadBalancerSourceRanges: "{{ LOADBALANCER_SOURCE_RANGES |default(['0.0.0.0/0'], -1) }}"
@@ -104,7 +104,7 @@ NFS_CLIENT_CONFIG:
   nfs:
     server: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"
     path: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/pvs"
-    mountOptions: 
+    mountOptions:
       - noatime
       - nodiratime
       - 'rsize=262144'
@@ -123,7 +123,7 @@ PG_NFS_CLIENT_CONFIG:
   nfs:
     server: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"
     path: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/pvs"
-    mountOptions: 
+    mountOptions:
       - noatime
       - nodiratime
       - 'rsize=262144'
@@ -209,6 +209,6 @@ private_ingress:
           service.beta.kubernetes.io/azure-load-balancer-internal: "true"
   gcp:
     controller:
-      service: 
+      service:
         annotations:
           networking.gke.io/load-balancer-type: "Internal"


### PR DESCRIPTION
# Changes
Prior to the introduction of the EBS CSI driver, dynamically provisioned EBS persistent volumes were tagged with the cluster name. That made it easy to look at the list of dynamically provisioned volumes in an AWS account and know which cluster they belonged to. Along with the introduction of the EBS CSI driver to dynamically provision volumes, that tagging was lost making it difficult to tell which cluster a volume belonged to.
 
The EBS CSI driver does support tagging by specifying a cluster name value for the k8sClusterId key in it's helm chart.
This update sets that key value to the cluster name when the EBS CSI driver helm chart is installed.

# Tests
|Scenario|Method|Task|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|-|
|1|OOTB|Ansible|AWS|1.25.9-eks|fast:2020|baseline,viya,install|deploy command|Deployment command completed successfully and all pods stabilized. All dynamically provisioned persistent volumes with the ebs csi driver have the cluster name prefix and are tagged with the cluster name|
|2|OOTB|Ansible|AWS|1.26.4-eks|fast:2020|baseline,viya,install|deploy command|Deployment completed successfully and all pods stabilized. All dynamically provisioned persistent volumes with the ebs csi driver have the cluster name prefix and are tagged with the cluster name| 