### PR TITLE
feat: (IAC-1014) Add Ability to Generate the site.yaml file

### DIFF
--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -101,7 +101,7 @@ V4_DEPLOYMENT_OPERATOR_CRB: sasoperator
 
 # SAS Orchestration Command
 # Experimental
-V4_SAS_ORCHESTRATION_USE_SITE_YAML: false
+V4_SAS_ORCHESTRATION_USE_SITE_YAML: true
 
 ## Below the line deployment -- internal use only
 ## Setting true enables using custom du for below the line testing

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -99,6 +99,9 @@ V4_DEPLOYMENT_OPERATOR_SCOPE: cluster
 V4_DEPLOYMENT_OPERATOR_NAMESPACE: sasoperator
 V4_DEPLOYMENT_OPERATOR_CRB: sasoperator
 
+# SAS Orchestration Command
+V4_SAS_ORCHESTRATION_USE_SITE_YAML: false
+
 ## Below the line deployment -- internal use only
 ## Setting true enables using custom du for below the line testing
 V4_CFG_BELOW_THE_LINE: false

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -100,6 +100,7 @@ V4_DEPLOYMENT_OPERATOR_NAMESPACE: sasoperator
 V4_DEPLOYMENT_OPERATOR_CRB: sasoperator
 
 # SAS Orchestration Command
+# Experimental
 V4_SAS_ORCHESTRATION_USE_SITE_YAML: false
 
 ## Below the line deployment -- internal use only

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -101,7 +101,7 @@ V4_DEPLOYMENT_OPERATOR_CRB: sasoperator
 
 # SAS Orchestration Command
 # Experimental
-V4_SAS_ORCHESTRATION_USE_SITE_YAML: true
+V4_SAS_ORCHESTRATION_USE_SITE_YAML: false
 
 ## Below the line deployment -- internal use only
 ## Setting true enables using custom du for below the line testing

--- a/roles/vdm/tasks/main.yaml
+++ b/roles/vdm/tasks/main.yaml
@@ -223,6 +223,19 @@
     - update
     - multi-tenancy
 
+# Only applicable for sas-orchestration based deployments
+# when the V4_SAS_ORCHESTRATION_USE_SITE_YAML flag is set
+- name: Include SAS Viya Kubernetes Manifest
+  include_tasks: sas_viya_kubernetes_manifest.yaml
+  when:
+    - not V4_DEPLOYMENT_OPERATOR_ENABLED
+    - V4_SAS_ORCHESTRATION_USE_SITE_YAML
+  tags:
+    - install
+    - uninstall
+    - update
+    - multi-tenancy
+
 - name: Include Deploy
   include_tasks: deploy.yaml
   when:

--- a/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
+++ b/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
@@ -33,7 +33,7 @@
         --volume "{{ DEPLOY_DIR }}:/data"
         --entrypoint kustomize
         "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        build /data/ {{ LOAD_RESTRICTOR_FLAG }} -o /data/site.yaml
+        build /data/ /data/site.yaml
       when:
         - deployment_tooling == "ansible"
     - name: SAS Viya Kubernetes Manifest - generate new site.yaml - Docker

--- a/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
+++ b/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
@@ -33,7 +33,7 @@
         --volume "{{ DEPLOY_DIR }}:/data"
         --entrypoint kustomize
         "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
-        build /data/ /data/site.yaml
+        build /data/ -o /data/site.yaml
       when:
         - deployment_tooling == "ansible"
     - name: SAS Viya Kubernetes Manifest - generate new site.yaml - Docker

--- a/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
+++ b/roles/vdm/tasks/sas_viya_kubernetes_manifest.yaml
@@ -1,0 +1,53 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The site.yaml SAS Viya Kubernetes manifest will only be generated if you set the
+# V4_SAS_ORCHESTRATION_USE_SITE_YAML flag and are setting the V4_DEPLOYMENT_OPERATOR_ENABLED flag to false so that
+# the sas-orchestration deploy command is being used to orchestrate the deployment.
+# If the V4_SAS_ORCHESTRATION_USE_SITE_YAML flag is not set, the generated SASDeployment Custom resource
+# used for the deployment.
+# See roles/vdm/tasks/sasdeployment_custom_resource.yaml
+---
+
+# NOTE: At this point in time we are only generating the site.yaml file so a
+# user could potentially perform a deployment using the "kubernetes commands" method
+# Changes are planned to make use of the site.yaml later.
+
+- name: SAS Viya Kubernetes Manifest - clean up site.yaml
+  file:
+    state: absent
+    path: "{{ DEPLOY_DIR }}/site.yaml"
+  tags:
+    - install
+    - update
+    - cas-onboard
+    - offboard
+
+- name: SAS Viya Kubernetes Manifest - generate site.yaml
+  block:
+    - name: SAS Viya Kubernetes Manifest - generate new site.yaml - Ansible
+      ansible.builtin.shell: >
+        docker run --rm
+        --user="{{ UID_GID }}"
+        --name "orchestration_{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+        --volume "{{ DEPLOY_DIR }}:/data"
+        --entrypoint kustomize
+        "{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }}"
+        build /data/ {{ LOAD_RESTRICTOR_FLAG }} -o /data/site.yaml
+      when:
+        - deployment_tooling == "ansible"
+    - name: SAS Viya Kubernetes Manifest - generate new site.yaml - Docker
+      environment:
+        PATH: "{{ ORCHESTRATION_TOOLING_PATH }}"
+      command:
+        cmd: |
+          kustomize build {{ DEPLOY_DIR }}/ -o {{ DEPLOY_DIR }}/site.yaml
+      args:
+        chdir: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}"
+      when:
+        - deployment_tooling == "docker"
+  tags:
+    - install
+    - update
+    - cas-onboard
+    - offboard


### PR DESCRIPTION
### Changes

**Experimental:** Adds the ability to generate the site.yaml for kubernetes commands based deployments.

To generate the site.yaml, you must first the opt to use the `sas-orchestration deploy` deployment method by setting our existing variable, `V4_DEPLOYMENT_OPERATOR_ENABLED:false` in your ansible-vars.yaml. Additionally, you must set the `V4_SAS_ORCHESTRATION_USE_SITE_YAML:true` variable in your ansible-vars.yaml to enable the site.yaml generation.

NOTE: At this point in time we are **ONLY** generating the site.yaml file so a user could potentially perform a deployment using the "kubernetes commands" method. Changes are planned to make use of the site.yaml later.


### Tests

| Scenario | Provider | K8s Version     | Deployment Method | Order  | Cadence   | DEPLOY | V4_DEPLOYMENT_OPERATOR_ENABLED | V4_SAS_ORCHESTRATION_USE_SITE_YAML | MT Tasks            | Notes                                                                                                                                     |
|----------|----------|-----------------|-------------------|--------|-----------|--------|--------------------------------|------------------------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| 1        | GCP      | v1.26.4-gke.500 | Docker            | * | fast:2020 | true   | false                          | true                               | n/a                 | site.yaml generated                                                                                                                       |
| 2        | GCP      | v1.26.4-gke.500 | Ansible           | * | fast:2020 | true   | false                          | true                               | n/a                 | site.yaml generated                                                                                                                       |
| 3        | GCP      | v1.26.4-gke.500 | Docker            | * | fast:2020 | true   | false                          | false                              | n/a                 | site.yaml not generated since V4_SAS_ORCHESTRATION_USE_SITE_YAML:false                                                                    |
| 4        | GCP      | v1.26.4-gke.500 | Docker            | * | fast:2020 | true   | true                           | true                               | n/a                 | site.yaml not generated since user opted to use DO with V4_DEPLOYMENT_OPERATOR_ENABLED:true                                                                   |
| 5        | GCP      | v1.26.4-gke.500 | Ansible            | * | fast:2020 | true   | false                          | true                               | onboard,cas-onboard | site.yaml regenerated after tenant resources added to kustomization.yaml                                                                  |
| 6        | GCP      | v1.26.4-gke.500 | Docker            | * | fast:2020 | false  | false                          | false                              | n/a                 | Nothing was deployed into the cluster, mimics the workflow a user would take if they wanted to perform the kubernetes commands themselves |

