### PR TITLE
fix: (IAC-1052) add MT tags to the 'Set env_path' tasks

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -26,17 +26,17 @@
     - offboard
 - block:
     - name: Parse tfstate
-      set_fact: 
+      set_fact:
         tfstate: "{{ lookup('tfstate', TFSTATE) }}"
     - name: default LOADBALANCER_SOURCE_RANGES
       set_fact:
         LOADBALANCER_SOURCE_RANGES: ["0.0.0.0/0"]
-      when: 
+      when:
         - LOADBALANCER_SOURCE_RANGES is not defined
     - name: Add nat ip to LOADBALANCER_SOURCE_RANGES
       set_fact:
         LOADBALANCER_SOURCE_RANGES: "{{ LOADBALANCER_SOURCE_RANGES + [tfstate.nat_ip.value+'/32'] }}"
-      when: 
+      when:
         - tfstate.nat_ip is defined
         - tfstate.nat_ip.value|length > 0
         - (tfstate.nat_ip.value+'/32') not in LOADBALANCER_SOURCE_RANGES
@@ -53,13 +53,13 @@
     - name: tfstate - nfs endpoint
       set_fact:
         V4_CFG_RWX_FILESTORE_ENDPOINT: "{{ tfstate.rwx_filestore_endpoint.value }}"
-      when: 
+      when:
         - tfstate.rwx_filestore_endpoint is defined
         - tfstate.rwx_filestore_endpoint.value|length > 0
     - name: tfstate - nfs path
       set_fact:
         V4_CFG_RWX_FILESTORE_PATH: "{{ tfstate.rwx_filestore_path.value }}"
-      when: 
+      when:
         - tfstate.rwx_filestore_path is defined
         - tfstate.rwx_filestore_path.value|length > 0
     - name: tfstate - export kubeconfig
@@ -78,19 +78,19 @@
         - tfstate.kube_config is defined
         - tfstate.kube_config.value|length > 0
     - name: tfstate - provider
-      set_fact: 
+      set_fact:
         PROVIDER: "{{ tfstate.provider.value }}"
       when:
         - tfstate.provider is defined
         - tfstate.provider.value|length > 0
     - name: tfstate - provider account
-      set_fact: 
+      set_fact:
         PROVIDER_ACCOUNT: "{{ tfstate.provider_account.value }}"
       when:
         - tfstate.provider_account is defined
         - tfstate.provider_account.value|length > 0
     - name: tfstate - cluster name
-      set_fact: 
+      set_fact:
         CLUSTER_NAME: "{{ tfstate.cluster_name.value }}"
       when:
         - tfstate.cluster_name is defined
@@ -102,25 +102,25 @@
         - tfstate.postgres_servers is defined
         - tfstate.postgres_servers.value|length > 0
     - name: tfstate - ebs csi driver account
-      set_fact: 
+      set_fact:
         EBS_CSI_DRIVER_ACCOUNT: "{{ tfstate.ebs_csi_account.value }}"
       when:
         - tfstate.ebs_csi_account is defined
         - tfstate.ebs_csi_account.value|length > 0
     - name: tfstate - ebs csi driver location
-      set_fact: 
+      set_fact:
         EBS_CSI_DRIVER_LOCATION: "{{ tfstate.location.value }}"
       when:
         - tfstate.location is defined
         - tfstate.location.value|length > 0
     - name: tfstate - cluster autoscaler account
-      set_fact: 
+      set_fact:
         CLUSTER_AUTOSCALER_ACCOUNT: "{{ tfstate.autoscaler_account.value }}"
       when:
         - tfstate.autoscaler_account is defined
         - tfstate.autoscaler_account.value|length > 0
     - name: tfstate - cluster autoscaler location
-      set_fact: 
+      set_fact:
         CLUSTER_AUTOSCALER_LOCATION: "{{ tfstate.location.value }}"
       when:
         - tfstate.location is defined
@@ -270,6 +270,9 @@
     - install
     - uninstall
     - update
+    - onboard
+    - cas-onboard
+    - offboard
 
 - name: baseline - gcloud auth use service account
   shell: |
@@ -297,7 +300,7 @@
     - name: Fail empty value
       fail:
         msg: "V4_CFG_MANAGE_STORAGE is defined but empty, supported values are true or false."
-      when: 
+      when:
         - V4_CFG_MANAGE_STORAGE is defined
         - V4_CFG_MANAGE_STORAGE == ''
       tags:
@@ -305,14 +308,14 @@
     - name: Fail unsupported values
       fail:
         msg: "The value provided for V4_CFG_MANAGE_STORAGE is unsupported, supported values are true or false."
-      when: 
-        - V4_CFG_MANAGE_STORAGE|lower != 'false' 
+      when:
+        - V4_CFG_MANAGE_STORAGE|lower != 'false'
         - V4_CFG_MANAGE_STORAGE|lower != 'true'
       tags:
         - always
 
 - name: migrations
-  include_tasks: 
+  include_tasks:
     file: migrations.yaml
   tags:
     - install

--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -60,7 +60,7 @@
         - not V4_CFG_BELOW_THE_LINE
     - name: deploy BLT - Deploy SAS Viya
       environment:
-        PATH: "{{ ORCHESTRATION_TOOLING_PATH }}"
+        PATH: "{{ env_path + ':' + ORCHESTRATION_TOOLING_PATH }}"
         KUBECONFIG: "{{ KUBECONFIG }}"
         WORK_DIRECTORY: "{{ ORCHESTRATION_TOOLING_DIRECTORY }}/work"
         EXPERIMENTAL_FEATURE_LOCAL_DEPLOYMENT_ASSETS: true


### PR DESCRIPTION
# Changes

- add multi-tenancy task tags to the set of tasks that will define env_path variable
- add env_path to PATH environment for below the line deployment when running DAC as a docker container. [Below the line deployment](https://github.com/sassoftware/viya4-deployment/pull/430) is an internal use only feature.

# Tests
See internal ticket for additional details.
|Scenario|Method|kubeconfig |Task|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|-|-|
|1|OOTB|provider based |docker|AWS|1.25.9-eks|fast:2020|baseline,viya,install|deploy command|Deployment command completed successfully and all pods stabilized. V4MT_ENABLE: true, V4MT_MODE: "schema", V4MT_TENANT_IDS: "acme", |
|2|OOTB|provider based |docker|AWS|1.25.9-eks|fast:2020|multi-tenancy,onboard,cas-onboard|deploy command | all three tasks completed successfully with all pods stabilized. sas-cas-server-acme-default-controller is 3/3 Ready and reached Running state |
|3|OOTB|provider based |docker|AWS|1.25.9-eks|fast:2020|multi-tenancy,offboard|deploy command | offboard tasks completed successfully with other Running pods stabilized. sas-cas-server-acme-default-controller was successfully terminated |
|4|OOTB|provider based|docker|AWS|1.25.9-eks|fast:2020|viya,uninstall|deploy command | viya uninstall tasks completed successfully |

Before adding env_path to PATH for deploy BLT - Deploy SAS Viya task

|Scenario|Method|kubeconfig |Task|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|-|-|
|5|OOTB|provider based|docker below-the-line|AWS|1.25.9-eks|fast:2020|viya,install|deploy command | Prior to adding env_path to PATH for docker based BLT deployment, deployment encounters the fatal error below indicating the the aws cli executable was not found|

Error for Scenario number 5 prior to change
``` 
  start: '2023-05-31 18:05:45.778874'
  stderr: |-
    Warning: 'EXPERIMENTAL_FEATURE_LOCAL_DEPLOYMENT_ASSETS' has been enabled. The behavior for 'EXPERIMENTAL_FEATURE_LOCAL_DEPLOYMENT_ASSETS' may change, or even be removed, in future releases.
    Error: Cannot create client for namespace 'deploy'
     Caused by:
            * Get "https://76E82B98902FD22511963025830C3917.gr7.us-east-2.eks.amazonaws.com/api?timeout=32s": getting credentials: exec: executable aws not found

             It looks like you are trying to use a client-go credential plugin that is not installed.

             To learn more about this feature, consult the documentation available at:
                   https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins               
```

After adding env_path to PATH for deploy BLT - Deploy SAS Viya task

|Scenario|Method|kubeconfig |Task|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|-|-|
|6|OOTB|provider based|docker below-the-line|AWS|1.25.9-eks|fast:2020|viya,install|deploy command | Successful BLT deployment, all pods stabilized and Running. Successful login with admin user to ingress |