### PR TITLE
fix: (IAC-975) undefined variable error occurs in set facts for cds-postgres role task

### DIFF
--- a/roles/vdm/tasks/deploy.yaml
+++ b/roles/vdm/tasks/deploy.yaml
@@ -137,6 +137,7 @@
     state: absent
     src: "{{ ORCHESTRATION_TOOLING_UNINSTALL_MANIFEST }}"
     wait: true
+    wait_timeout: 600
     namespace: "{{ NAMESPACE }}"
     kubeconfig: "{{ KUBECONFIG }}"
   ignore_errors: yes

--- a/roles/vdm/tasks/postgres/postgres-instance.yaml
+++ b/roles/vdm/tasks/postgres/postgres-instance.yaml
@@ -141,6 +141,16 @@
       register: cm_info
     - name: postgres instance - set facts for either role from configMap keys
       block:
+      - name: postgres instance - check for cds values
+        block:
+        - name:
+          set_fact:
+            dac_crunchy_storage_cm_cds_values_present: false
+          when: cm_info.resources[0].data['cds-postgres-storage-class'] is not defined
+        - name:
+          set_fact:
+            dac_crunchy_storage_cm_cds_values_present: true
+          when: cm_info.resources[0].data['cds-postgres-storage-class'] is defined
 
       - name: postgres instance - set facts for default role
         set_fact:
@@ -156,7 +166,9 @@
           cds_postgres_pvc_access_mode: "{{ cm_info.resources[0].data['cds-postgres-access-mode'] }}"
           cds_backrest_storage_class: "{{ cm_info.resources[0].data['cds-backrest-storage-class'] }}"
           cds_backrest_pvc_access_mode: "{{ cm_info.resources[0].data['cds-backrest-access-mode'] }}"
-        when: role == 'cds-postgres'
+        when: 
+          - dac_crunchy_storage_cm_cds_values_present
+          - role == 'cds-postgres'
 
       when: 
         - dac_crunchy_storage_cm_found
@@ -234,7 +246,7 @@
               cds-backrest-storage-class: "{{ cds_backrest_storage_class | string }}"
               cds-backrest-access-mode: "{{ cds_backrest_pvc_access_mode | string }}"
       when: 
-        - not dac_crunchy_storage_cm_found
+        - not dac_crunchy_storage_cm_found or not dac_crunchy_storage_cm_cds_values_present
         - DEPLOY
         - role == "cds-postgres"
   when:


### PR DESCRIPTION
# Changes
- set fact indicating cds-postgres content in storage configmap, use fact to gate references
- Add wait_timeout for Remove Viya task consistent with other similar tasks, this should help reduce the frequency of 120 second task timeout messages that are ignored with current task settings.

# Tests
See internal ticket for additional details.
|Scenario|Task|method|Provider|k8s version|Cadence|tasks|Deploy method|Remarks|
|-|-|-|-|-|-|-|-|-|
|1|OOTB, internal(default)|Ansible|Azure|1.25.6|fast:2020|baseline,viya,install|deploy command|Deployment command completed successfully and all pods stabilized.|
|2|After scenario # 1 without uninstalling, internal(default,cds-postgres)|Ansible|Azure|1.25.6|fast:2020|viya,install|deploy command|Deployment command completed successfully and all pods stabilized including default and cds-postgres internal instance pods. IAC-975 was opened on this scenario.|
|3|OOTB, internal(default,cds-postgres)|Ansible|Azure|1.25.6|fast:2020|baseline,viya,install|deploy command|All pods up and stabilzed including default and cds-postgres internal instance pods|
|4|Re-install after scenario # 3, internal(default,cds-postgres)|Ansible|Azure|1.25.6|fast:2020|viya,install|deploy command|deployment completed successfully with all pods stabilized. Expected Ansible output message: TASK [vdm : pg_config - Use previous postgres storage map values] "The previously found values for the postgres server storage class and access mode will be used.", "The values you have in your ansible vars will be ignored because the storage class is already present in your cluster."|
|5|Re-install after scenario # 3, internal(default,cds-postgres), config updated with a new cds-postgres storage class|Ansible|Azure|1.25.6|fast:2020|viya,install|deploy command|deployment completed successfully with all pods stabilized and all Postgres PVCs bound with initially configured pg-storage storage class. New cds-postgres storage class value was ignored as expected. Expected Ansible output message: "The previously found values for the postgres server storage class and access mode will be used.", "The values you have in your ansible vars will be ignored because the storage class is already present in your cluster."|
|6|OOTB, external postgres(default)|Ansible|Azure|1.25.6|fast:2020|baseline,viya,install|deploy command|Deployment command completed successfully with all pods stabilized.|