### PR TITLE
feat: (IAC-1107) Update Google Cloud CLI to 440.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v{$kubec
 FROM baseline
 ARG helm_version=3.12.0
 ARG aws_cli_version=2.7.22
-ARG gcp_cli_version=428.0.0-0
+ARG gcp_cli_version=440.0.0-0
 
 # Add extra packages
 RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass skopeo rsync \

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -27,7 +27,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 If you are using a provider based kubeconfig file created by viya4-iac-gcp:4.5.0 or newer, install these dependencies:
 | SOURCE         | NAME                    | VERSION     |
 |----------------|-------------------------|-------------|
-| ~              | gcloud                  | 428.0.0     |
+| ~              | gcloud                  | 440.0.0     |
 | ~              | gcloud-gke-auth-plugin  | >= 0.5.2    |
 
 Required project dependencies are generally pinned to known working or stable versions to ensure users have a smooth initial experience. In some cases it may be required to change the default version of a dependency. In such cases users are welcome to experiment with alternate versions, however compatibility may not be guaranteed.


### PR DESCRIPTION
### Changes

Updates the Google Cloud CLI to 440.0.0 to pick up the latest updates

### Tests

| Scenario | Provider | gcloud version | K8s Version      | Kubeconfig  | Orchestration | Order  | Cadence        |
|----------|----------|----------------|------------------|-------------|---------------|--------|----------------|
| 1        | GCP      | 440.0.0        | v1.26.5-gke.2700 | static      | DO            | * | fast:2020      |
| 2        | GCP      | 440.0.0        | v1.26.5-gke.2700 | auth plugin | DO            | * | stable:2023.07 |