### PR TITLE
docs: (IAC-1134) Update Python version dependency required for installing Ansible 8.0.0

### DIFF
--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -6,7 +6,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 
 | SOURCE         | NAME             | VERSION     |
 |----------------|------------------|-------------|
-| ~              | python           | 3.x         |
+| ~              | python           | >=3.9       |
 | ~              | pip              | 3.x         |
 | ~              | unzip            | any         |
 | ~              | tar              | any         |
@@ -14,7 +14,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | git              | any         |
 | ~              | rsync            | any         |
 | ~              | kubectl          | 1.24 - 1.26 |
-| ~              | Helm             | 3           |
+| ~              | Helm             | 3.12.0      |
 | pip3           | ansible          | 8.0.0       |
 | pip3           | openshift        | 0.13.1      |
 | pip3           | kubernetes       | 26.1.0      |

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -14,7 +14,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | git              | any         |
 | ~              | rsync            | any         |
 | ~              | kubectl          | 1.24 - 1.26 |
-| ~              | Helm             | 3.12.0      |
+| ~              | Helm             | 3           |
 | pip3           | ansible          | 8.0.0       |
 | pip3           | openshift        | 0.13.1      |
 | pip3           | kubernetes       | 26.1.0      |


### PR DESCRIPTION
For PR https://github.com/sassoftware/viya4-deployment/pull/455, the Ansible version was updated to resolve security vulnerabilities that were picked up by our scanning process. Installing Ansible 8.0.0 to run DAC locally with the ansible-playbook CLI command will require users to have Python version 3.9 or later installed. This doc update modifies the Python version dependency to indicate that Python version 3.9 or greater is required to install Ansible 8.0.0.