### PR TITLE
feat: (IAC-1044) update ingress-nginx default to v1.8.1

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -396,7 +396,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.23.X, and version 4.6.0 is used for Kubernetes clusters whose version is >= 1.24.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.23.X, and version 4.7.1 is used for Kubernetes clusters whose version is >= 1.24.X. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -39,8 +39,8 @@ ingressVersions:
   k8sMinorVersionFloor:
     value: 24
     api:
-      chartVersion: 4.6.0
-      appVersion: 1.7.0
+      chartVersion: 4.7.1
+      appVersion: 1.8.1
 
 ## Ingress-nginx - Ingress
 ##


### PR DESCRIPTION
### Changes

* Update the default Ingress-nginx `chartVersion` used to v4.7.1, and `appVersion` used to v1.8.1 for kubernetes cluster versions 1.24 or later  
* Update CONFIG-VARS.md to indicate that the default `INGRESS_NGINX_CHART_VERSION` is 4.7.1 for  kubernetes clusters whose version is >= 1.24

### Tests

| Scenario | Provider | kubernetes_version | ingress-NGINX version | ingress-nginx helm chart version | order  | cadence   | notes             |
|----------|----------|-------------------------|-----------------|--------|-----------|-------------------|----|
| 1 | Azure | 1.26 (v1.26.6) | 1.8.1 | 4.7.1 | **| ** | DAC ansible, deploy cmd: successful baseline,viya install, all pods stabilized, successful viya_admin login to Viya application |
| 2 | Azure | 1.25 (v1.25.11) | 1.8.1 | 4.7.1 | n/a | n/a | DAC ansible, baseline install results: ingress-nginx-controller v1.8.1 at helm chart v4.7.1 is installed, see 1044-scenario.md file for k8s 1.25 console output |
| 3 | Azure | 1.27 (v1.27.3) | 1.8.1 | 4.7.1 | n/a | n/a | DAC ansible, baseline install results: ingress-nginx-controller v1.8.1 at helm chart v4.7.1 is installed, see 1044-scenario.md file for k8s 1.27 console output |
| 4 | AWS | 1.25 (v1.25.12-eks) | 1.8.1 | 4.7.1 | n/a | n/a | DAC ansible, baseline install results: ingress-nginx-controller v1.8.1 at helm chart v4.7.1 is installed, see 1044-scenario.md file for console output |
| 5 | Azure | 1.24 (v1.24.15) | 1.8.1 | 4.7.1 | n/a | n/a | DAC ansible, baseline install results: ingress-nginx-controller v1.8.1 at helm chart v4.7.1 is installed, see 1044-scenario.md file for console output |