### PR TITLE
feat: (IAC-1047) Update to newer release for cluster-autoscaler in EKS

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -366,7 +366,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | CLUSTER_AUTOSCALER_ENABLED | Whether to deploy cluster-autoscaler | bool | true | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://kubernetes.github.io/autoscaler) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_NAME| Cluster-autoscaler Helm chart name | string | cluster-autoscaler | false | | baseline |
-| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.9.2 is used for Kubernetes clusters whose version is <= 1.21 <br> and version 9.25.0 is used for Kubernetes clusters whose version is >= 1.25 | baseline |
+| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.9.2 is used for Kubernetes clusters whose version is <= 1.21 <br> and version 9.29.1 is used for Kubernetes clusters whose version is >= 1.25 | baseline |
 | CLUSTER_AUTOSCALER_CONFIG | Cluster-autoscaler Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_ACCOUNT | Cluster autoscaler AWS role ARN | string | | false | Required to enable cluster-autoscaler on AWS | baseline |
 | CLUSTER_AUTOSCALER_LOCATION |AWS region where Kubernetes cluster is running | string | us-east-1 | false | | baseline |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -364,7 +364,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | CLUSTER_AUTOSCALER_ENABLED | Whether to deploy cluster-autoscaler | bool | true | false | | baseline |
-| CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://kubernetes.github.io/autoscaler) for more information. | false | | baseline |
+| CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://github.com/kubernetes/autoscaler/tree/master/charts) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_NAME| Cluster-autoscaler Helm chart name | string | cluster-autoscaler | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.9.2 is used for Kubernetes clusters whose version is <= 1.21 <br> and version 9.29.1 is used for Kubernetes clusters whose version is >= 1.25 | baseline |
 | CLUSTER_AUTOSCALER_CONFIG | Cluster-autoscaler Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -173,8 +173,7 @@ autoscalerVersions:
   # Supports PodDisruptionBudget policy/v1beta1 default for K8s >=1.25
   PDBv1Support:
     api:
-      chartVersion: 9.25.0
-      appVersion: 1.24.0
+      chartVersion: 9.29.1
 
 ## EBS CSI Driver
 EBS_CSI_DRIVER_ENABLED: true


### PR DESCRIPTION
### Changes

* Update the default `CLUSTER_AUTOSCALER_CHART_VERSION` documentation to indicate that a helm `chartVersion` of 9.29.1 will be used for EKS Kubernetes clusters whose version is >= 1.25
* Update the `chartVersion` value to 9.29.1 that will be used for Kubernetes clusters using versions 1.25 or later
* Remove the `appVersion` value from the `CLUSTER_AUTOSCALER_CONFIG` for the latest `autoScalerVersions` entry, Thomas advised that it can be misleading to provide an `appVersion` since the `appVersion` field is informational only and has no impact on the chart version calculations.

### Tests

| Scenario | Provider | kubernetes_version | cluster-autoscaler chart version | cluster-autoscaler application Version | order | cadence | notes |
|----------|----------|--------------------|-----------------------|----------------------------------|--------|-----------|----|
| 1 | AWS | 1.26 (v1.26.7-eks) | 9.29.1 | 1.27.2 | n/a | n/a | iac-aws apply created cluster with min_node=1 for each worker node group. Stopped the single CAS node instance, the autoscaler restarted a new one to replace it within a few minutes, see PNG screen captures in the scenario1 folder of the IAC-1047.zip file |
| 2 | AWS | 1.26 (v1.26.7-eks) | 9.29.1 | 1.27.2 | n/a | n/a | iac-aws apply created cluster with min_node=3 for the stateless node group. 3 stateless nodes were created as indicated. Stopped 2 stateless node instances, as each stateless node moved to the fully terminated state, the autoscaler created a new node to replace the terminated node within a few minutes, see PNG screen captures in the scenario2 folder of the IAC-1047.zip file |