### PR TITLE
docs: (IAC-1109) Add EBS CSI Driver section to ToC in CONFIG-VARS.md

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -27,6 +27,7 @@ Supported configuration variables are listed in the table below.  All variables 
   - [Third-Party Tools](#third-party-tools)
     - [Cert-manager](#cert-manager)
     - [Cluster Autoscaler](#cluster-autoscaler)
+    - [EBS CSI Driver](#ebs-csi-driver)
     - [Ingress-nginx](#ingress-nginx)
     - [Metrics Server](#metrics-server)
     - [NFS Client](#nfs-client)


### PR DESCRIPTION
### Changes
Add missing EBS CSI Driver section to the table of contents for CONFIG-VARS.md, https://github.com/sassoftware/viya4-deployment/blob/main/docs/CONFIG-VARS.md
The new "EBS CSI Driver" entry follows the "Cluster Autoscaler" entry
![pastedImage](https://github.com/sassoftware/viya4-deployment/assets/6422249/5678e08e-ca82-48e6-bcab-200fc1d6b2f2)
