### PR TITLE
feat: (IAC-1003) Update deprecated provisioner in V4M Azure storageclass

### DIFF
--- a/roles/monitoring/files/azure-storageclass.yaml
+++ b/roles/monitoring/files/azure-storageclass.yaml
@@ -12,7 +12,6 @@ metadata:
   name: v4m
 parameters:
   skuName: Standard_LRS
-# provisioner: kubernetes.io/azure-disk  ## check if still required for K8s <=1.25
 provisioner: disk.csi.azure.com
 reclaimPolicy: Delete
 # Set binding mode to WaitForFirstConsumer to avoid

--- a/roles/monitoring/files/azure-storageclass.yaml
+++ b/roles/monitoring/files/azure-storageclass.yaml
@@ -12,7 +12,8 @@ metadata:
   name: v4m
 parameters:
   skuName: Standard_LRS
-provisioner: kubernetes.io/azure-disk
+# provisioner: kubernetes.io/azure-disk  ## check if still required for K8s <=1.25
+provisioner: disk.csi.azure.com
 reclaimPolicy: Delete
 # Set binding mode to WaitForFirstConsumer to avoid
 # volume node affinity issues


### PR DESCRIPTION
# Changes:
Updated Azure deployment storageclass to replace storage provisioner deprecated in AKS for K8s v1.26+. This change is based on the change made in the `viya4-monitoring-kubernetes` repo [PR #481](https://github.com/sassoftware/viya4-monitoring-kubernetes/pull/481/files)

# Tests:
Verified logging and monitoring component deployed correctly as expected using the new provisioner on the following scenarios, see details in internal ticket

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|
|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.25|ansible, DO: true|
|2|OOTB|Azure|fast:2020|1.26|ansible, DO: false|