### PR TITLE
feat: (IAC-1146) DAC updates to support AWS NetApp ONTAP

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -27,6 +27,7 @@ Supported configuration variables are listed in the table below.  All variables 
   - [Third-Party Tools](#third-party-tools)
     - [Cert-manager](#cert-manager)
     - [Cluster Autoscaler](#cluster-autoscaler)
+    - [FSx ONTAP CSI Driver](#fsx-ontap-csi-driver)
     - [Ingress-nginx](#ingress-nginx)
     - [Metrics Server](#metrics-server)
     - [NFS Client](#nfs-client)
@@ -388,6 +389,15 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | EBS_CSI_DRIVER_CONFIG | aws ebs csi driver helm values | string | see [here](../roles/baseline/defaults/main.yml) | false | | baseline |
 | EBS_CSI_DRIVER_ACCOUNT | cluster autoscaler aws role arn | string | | false | Required to enable the aws ebs csi driver on AWS | baseline |
 | EBS_CSI_DRIVER_LOCATION | aws region where kubernetes cluster resides | string | us-east-1 | false | | baseline |
+
+### FSX ONTAP CSI Driver
+
+| <div style="width:50px">Name</div> | <div style="width:150px">Description</div> | <div style="width:35px">Type</div> | <div style="width:50px">Default</div>| <div style="width:60px">Required</div>  | <div style="width:40px">Notes</div> | <div style="width:50px">Tasks</div> |
+| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+| AWS_FSX_ONTAP_FSXADMIN_PASSWORD | You use the fsxadmin user to access the NetApp ONTAP CLI and REST API to manage your file system resources. For more information, see [Managing resources using NetApp Applicaton](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/managing-resources-ontap-apps.html). | string |  | false | | baseline |
+| AWS_FSX_ONTAP_FILE_SYSTEM_MANAGEMENT_ENDPOINT |  | string |  | false | | baseline |
+| AWS_FSX_ONTAP_STORAGE_VIRTUAL_MACHINE_NAME |  | string |  | false | | baseline |
+
 
 ### Ingress-nginx
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -7,6 +7,7 @@ V4_CFG_RWX_FILESTORE_PATH: /export
 V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_MODE: public
 V4_CFG_MANAGE_STORAGE: true
+V4_CFG_STORAGECLASS: sas
 
 ## Cert-manager
 CERT_MANAGER_NAME: cert-manager
@@ -211,3 +212,19 @@ private_ingress:
       service:
         annotations:
           networking.gke.io/load-balancer-type: Internal
+
+## Trident CSI Driver
+TRIDENT_CSI_DRIVER_ENABLED: true
+TRIDENT_CSI_DRIVER_NAME: aws-trident-csi-driver
+TRIDENT_CSI_DRIVER_NAMESPACE: kube-system
+TRIDENT_CSI_DRIVER_CHART_NAME: trident-operator
+TRIDENT_CSI_DRIVER_CHART_URL: https://netapp.github.io/trident-helm-chart
+TRIDENT_CSI_DRIVER_CHART_VERSION: 23.07.0
+TRIDENT_CSI_DRIVER_ACCOUNT: null
+TRIDENT_CSI_DRIVER_LOCATION: us-east-1
+TRIDENT_CSI_DRIVER_CONFIG:
+  nodeSelector:
+
+AWS_FSX_ONTAP_FSXADMIN_PASSWORD: Password123
+AWS_FSX_ONTAP_FILE_SYSTEM_MANAGEMENT_ENDPOINT: null
+AWS_FSX_ONTAP_STORAGE_VIRTUAL_MACHINE_NAME: null

--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -71,6 +71,16 @@
   tags:
     - baseline
 
+- name: Include trident-csi-driver
+  include_tasks:
+    file: trident-csi-driver.yaml
+  when:
+    - PROVIDER == "aws"
+    - TRIDENT_CSI_DRIVER_ACCOUNT is defined
+    - TRIDENT_CSI_DRIVER_ACCOUNT is not none
+  tags:
+    - baseline
+
 - name: Include cert manager
   include_tasks:
     file: cert-manager.yaml

--- a/roles/baseline/tasks/trident-csi-driver.yaml
+++ b/roles/baseline/tasks/trident-csi-driver.yaml
@@ -1,0 +1,57 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Deploy trident-csi-driver
+  kubernetes.core.helm:
+    name: "{{ TRIDENT_CSI_DRIVER_NAME }}"
+    namespace: "{{ TRIDENT_CSI_DRIVER_NAMESPACE }}"
+    chart_repo_url: "{{ TRIDENT_CSI_DRIVER_CHART_URL }}"
+    chart_ref: "{{ TRIDENT_CSI_DRIVER_CHART_NAME }}"
+    chart_version: "{{ TRIDENT_CSI_DRIVER_CHART_VERSION }}"
+    values: "{{ TRIDENT_CSI_DRIVER_CONFIG }}"
+    kubeconfig: "{{ KUBECONFIG }}"
+    wait: true
+  when:
+    - TRIDENT_CSI_DRIVER_ENABLED
+  tags:
+    - install
+    - update
+
+- name: Create trident backend config resource from template
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/backend-tbc-ontap-nas.yaml"
+    dest: "{{ role_path }}/templates/resources/backend-tbc-ontap-nas.yaml"
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: Apply trident backend custom resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ KUBECONFIG }}"
+    wait: true
+    state: present
+    src: "{{ role_path }}/templates/resources/backend-tbc-ontap-nas.yaml"
+  tags:
+    - install
+    - update
+
+- name: Remove trident backend custom resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ KUBECONFIG }}"
+    state: absent
+    src: "{{ role_path }}/templates/resources/backend-tbc-ontap-nas.yaml"
+  tags:
+    - uninstall
+
+- name: Remove trident-csi-driver
+  kubernetes.core.helm:
+    name: "{{ TRIDENT_CSI_DRIVER_NAME }}"
+    namespace: "{{ TRIDENT_CSI_DRIVER_NAMESPACE }}"
+    kubeconfig: "{{ KUBECONFIG }}"
+    wait: true
+    values: "{{ TRIDENT_CSI_DRIVER_CONFIG }}"
+    state: absent
+  tags:
+    - uninstall

--- a/roles/baseline/templates/backend-tbc-ontap-nas.yaml
+++ b/roles/baseline/templates/backend-tbc-ontap-nas.yaml
@@ -1,0 +1,37 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-tbc-ontap-nas-secret
+  namespace: "{{ TRIDENT_CSI_DRIVER_NAMESPACE }}"
+type: Opaque
+stringData:
+  username: fsxadmin
+  password: "{{ AWS_FSX_ONTAP_FSXADMIN_PASSWORD }}"
+---
+apiVersion: trident.netapp.io/v1
+kind: TridentBackendConfig
+metadata:
+  name: backend-tbc-ontap-nas
+  namespace: "{{ TRIDENT_CSI_DRIVER_NAMESPACE }}"
+spec:
+  version: 1
+  storageDriverName: ontap-nas
+  managementLIF: "{{ AWS_FSX_ONTAP_FILE_SYSTEM_MANAGEMENT_ENDPOINT }}"
+  dataLIF: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"
+  backendName: tbc-ontap-nas
+  svm: "{{ AWS_FSX_ONTAP_STORAGE_VIRTUAL_MACHINE_NAME }}"
+  credentials:
+    name: backend-tbc-ontap-nas-secret
+---
+# apiVersion: storage.k8s.io/v1
+# kind: StorageClass
+# metadata:
+#   name: "{{ V4_CFG_STORAGECLASS }}"
+# provisioner: csi.trident.netapp.io
+# parameters:
+#   backendType: ontap-nas
+#   fsType: nfs

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -125,6 +125,30 @@
       when:
         - tfstate.location is defined
         - tfstate.location.value|length > 0
+    - name: tfstate - trident csi driver account # noqa: name[casing]
+      set_fact:
+        TRIDENT_CSI_DRIVER_ACCOUNT: "{{ tfstate.fsx_ontap_account.value }}"
+      when:
+        - tfstate.fsx_ontap_account is defined
+        - tfstate.fsx_ontap_account.value|length > 0
+    - name: tfstate - aws fsx ontap fs management endpoint # noqa: name[casing]
+      set_fact:
+        AWS_FSX_ONTAP_FILE_SYSTEM_MANAGEMENT_ENDPOINT: "{{ tfstate.aws_fsx_ontap_file_system_management_endpoint.value }}"
+      when:
+        - tfstate.aws_fsx_ontap_file_system_management_endpoint is defined
+        - tfstate.aws_fsx_ontap_file_system_management_endpoint.value|length > 0
+    - name: tfstate - aws fsx ontap storage virtual machine name # noqa: name[casing]
+      set_fact:
+        AWS_FSX_ONTAP_STORAGE_VIRTUAL_MACHINE_NAME: "{{ tfstate.aws_fsx_ontap_storage_virtual_machine_name.value }}"
+      when:
+        - tfstate.aws_fsx_ontap_storage_virtual_machine_name is defined
+        - tfstate.aws_fsx_ontap_storage_virtual_machine_name.value|length > 0
+    - name: tfstate - aws fsx ontap fsxadmin password # noqa: name[casing]
+      set_fact:
+        AWS_FSX_ONTAP_FSXADMIN_PASSWORD: "{{ tfstate.aws_fsx_ontap_fsxadmin_password.value }}"
+      when:
+        - tfstate.aws_fsx_ontap_fsxadmin_password is defined
+        - tfstate.aws_fsx_ontap_fsxadmin_password.value|length > 0
     - name: tfstate - cluster autoscaler account # noqa: name[casing]
       set_fact:
         CLUSTER_AUTOSCALER_ACCOUNT: "{{ tfstate.autoscaler_account.value }}"


### PR DESCRIPTION
## Changes 
DAC updates to support AWS NetApp ONTAP

Expecting to close this draft PR early next week as our current approach to support FSx for NetApp ONTAP in the viya4-iac-aws project will not require additional changes in the DAC project.