### PR TITLE
feat: (IAC-1147) DAC - Support K8s 1.27 in 2023.09

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.25.9
+ARG kubectl_version=1.26.8
 
 WORKDIR /build
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | docker           | >=20.10.10  |
 | ~              | git              | any         |
 | ~              | rsync            | any         |
-| ~              | kubectl          | 1.24 - 1.26 |
+| ~              | kubectl          | 1.25 - 1.27 |
 | ~              | Helm             | 3           |
 | pip3           | ansible          | 8.0.0       |
 | pip3           | openshift        | 0.13.1      |
@@ -48,7 +48,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.25.9 \
+	--build-arg kubectl_version=1.26.8 \
 	-t viya4-deployment .
 ```
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -35,12 +35,10 @@ ingressVersions:
     value: 23
     api:
       chartVersion: 4.3.0
-      appVersion: 1.4.0
   k8sMinorVersionFloor:
     value: 24
     api:
       chartVersion: 4.7.1
-      appVersion: 1.8.1
 
 ## Ingress-nginx - Ingress
 ##


### PR DESCRIPTION
# Changes:
SAS Viya Platform will support a range of K8s `1.25-1.27` in cadence `2023.09`. 

This PR contains following updates:
- The default kubectl version updated to `1.26.8`
- remove ingress-nginx AppVersion values per previous decision


# Tests:
Verified SAS Viya Platform deployment is successful on the following scenarios

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|Notes|
|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|AWS (1.27.3-eks) |fast:2020|1.27|ansible, DO: false| All pods stable in deployment, successful viya_admin login to Viya Application.
|2|OOTB|AWS (1.26.7-eks) |stable 2023.08|1.26|ansible, DO: true| All pods stable in deployment.
|3|OOTB|Azure (1.25.11) |stable 2023.06|1.25|docker, DO: false| All pods stable in deployment, successful viya_admin login to Viya Application.
|4|OOTB|AWS (1.25.12-eks) |stable 2023.07|1.25|docker, DO: false| All pods stable in deployment, successful viya_admin login to Viya Application.