### PR TITLE
feat: (IAC-1170) Update Default CERT_MANAGER_CHART_VERSION to 1.13.1

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -363,7 +363,7 @@ Notes:
 | CERT_MANAGER_NAMESPACE | cert-manager Helm installation namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager Helm chart URL | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager Helm chart name | string | cert-manager| false | | baseline |
-| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.11.0 | false | | baseline |
+| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.13.1 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 
 Notes:

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -13,7 +13,7 @@ CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
-CERT_MANAGER_CHART_VERSION: 1.11.0
+CERT_MANAGER_CHART_VERSION: 1.13.1
 CERT_MANAGER_CONFIG:
   installCRDs: "true"
   extraArgs:


### PR DESCRIPTION
### Changes

Update the default version of cert-manager to 1.13.1

cert-manager 1.13.1 is compatible with kubernetes versions 1.23 → 1.28, see supported
releases: https://cert-manager.io/docs/releases/

There are no breaking changes from the original default of 1.11.0 to 1.13.1, see the upgrade documentation here:

* https://cert-manager.io/docs/releases/upgrading/upgrading-1.11-1.12/
* https://cert-manager.io/docs/releases/upgrading/upgrading-1.12-1.13

### Tests

| Scenario | Task                      | Provider | K8s                 | V4_CFG_TLS_GENERATOR | CERT_MANAGER_CHART_VERSION | V4_CFG_TLS_MODE | V4_CFG_TLS_CERT/KEY/TRUSTED_CA_CERTS                               | order | cadence   |
|----------|---------------------------|----------|---------------------|----------------------|----------------------------|-----------------|--------------------------------------------------------------------|-------|-----------|
| 1        | OOTB + Logging/Monitoring | GCP      | v1.25.13-gke.200    | cert-manager	        | 1.13.1                     | front-door      | user provided                                                      | *     | fast:2020 |
| 2        | OOTB + Logging/Monitoring | GCP      | v1.25.13-gke.200    | cert-manager	        | 1.13.1                     | front-door      | generated                                                          | *     | fast:2020 |
| 3        | OOTB + Logging/Monitoring | AWS      | v1.26.7-eks-2d98532 | cert-manager	        | 1.13.1                     | full-stack      | user provided                                                      | *     | fast:2020 |
| 4        | OOTB + Logging/Monitoring | AWS      | v1.26.7-eks-2d98532 | cert-manager	        | 1.13.1                     | full-stack      | only provided TRUSTED_CA_CERTS, required for external RDS instance | *     | fast:2020 |
| 5        | OOTB + Logging/Monitoring | Azure    | v1.27.3             | cert-manager	        | 1.13.1                     | front-door      | user provided                                                      | *     | fast:2020 |
| 6        | OOTB + Logging/Monitoring | Azure    | v1.27.3             | cert-manager	        | 1.13.1                     | front-door      | generated                                                          | *     | fast:2020 |

