### PR TITLE
fix: (IAC-1072) Add AKS pod cidr to LOADBALANCER_SOURCE_RANGES

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -62,6 +62,16 @@
         - tfstate.gke_pod_subnet_cidr is defined
         - tfstate.gke_pod_subnet_cidr.value|length > 0
         - (tfstate.gke_pod_subnet_cidr.value) not in LOADBALANCER_SOURCE_RANGES
+    - name: tfstate - Add AKS pod cidr to LOADBALANCER_SOURCE_RANGES # noqa: name[casing]
+      set_fact:
+        LOADBALANCER_SOURCE_RANGES: "{{ LOADBALANCER_SOURCE_RANGES + [tfstate.aks_pod_cidr.value] }}"
+      when:
+        - tfstate.provider is defined
+        - tfstate.provider.value|length > 0
+        - tfstate.provider.value == "azure"
+        - tfstate.aks_pod_cidr is defined
+        - tfstate.aks_pod_cidr.value|length > 0
+        - (tfstate.aks_pod_cidr.value) not in LOADBALANCER_SOURCE_RANGES
     - name: tfstate - nfs endpoint # noqa: name[casing]
       set_fact:
         V4_CFG_RWX_FILESTORE_ENDPOINT: "{{ tfstate.rwx_filestore_endpoint.value }}"


### PR DESCRIPTION
## Changes
To enable the North-South traffic again in Azure, a task was added to include `aks_pod_cidr` in `LOADBALANCER_SOURCE_RANGES`.
For more details on this change see description of [Azure PR #341](https://github.com/sassoftware/viya4-iac-azure/pull/341).

## Tests:
Verified following scenarios, for details see internal ticket:

|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|OOTB, Defaults|Fast 2020|`aks_pod_cidr` is read from tfstate file and added to `LOADBALANCER_SOURCE_RANGES`. Viya4 deployment stabilized, applications were accessible and the example proc http to query an endpoint was successful |
|2|`aks_pod_cidr` was added to `LOADBALANCER_SOURCE_RANGES` in ansible-vars|Fast 2020|`aks_pod_cidr` was not read from tfstate file. `LOADBALANCER_SOURCE_RANGES` were set correctly. Viya4 deployment stabilized, applications were accessible and the example proc http to query an endpoint was successful|
