### PR TITLE
feat: (IAC-1228) Support Azure Application Gateway with Azure WAF

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -34,6 +34,7 @@ Supported configuration variables are listed in the table below.  All variables 
     - [NFS Client](#nfs-client)
     - [Postgres NFS Client](#postgres-nfs-client)
   - [Multi-tenancy](#multi-tenancy)
+  - [Azure Application Gateway with WAF](#azure-application-gateway-with-waf)
 
 ## BASE
 
@@ -498,4 +499,19 @@ V4MT_TENANT_CAS_CUSTOMIZATION:
     cpus: 250m
     worker_count: 1
     backup_controller_enabled: true
+```
+
+## Azure Application Gateway with WAF
+
+| Name | Description | Type | Default | Required | Notes | Tasks |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| V4_CFG_APPLICATION_GATEWAY_ENABLED | Enables Azure Application Gateway | bool | false | false | If not set, the value for this variable will be read from tfstate file | baseline |
+| INGRESS_NGINX_AZURE_DNS_LABEL_NAME | Setting this variable lets user use Azure public DNS by adding DNS label for Ingress loadbalancer  | string | null | false | | baseline |
+
+**Additional setting required for Azure application gateway:**
+
+In your `ansible-vars.yaml` file, the variable `V4_CFG_INGRESS_FQDN` should be setup with hostname of your application gateway. And for secure communication, ingress certificates should be set correctly. Following variables should help setting up the ingress certificate.
+```
+V4_CFG_TLS_CERT: "<Path to ingress certificate file>" ## This file should have all, leaf (server) → intermediate → root certs
+V4_CFG_TLS_KEY: "<Path to ingress key file>"
 ```

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -71,6 +71,16 @@ INGRESS_NGINX_CONFIG:
           command: [/bin/sh, -c, sleep 5; /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -s quit; while pgrep -x nginx; do sleep 1; done]
     terminationGracePeriodSeconds: 600
 
+# Add config and annotation for Azure Application Gateway
+V4_CFG_APPLICATION_GATEWAY_ENABLED: false
+INGRESS_NGINX_AZURE_GATEWAY_CONFIG:
+  controller:
+    config:
+      use-forwarded-headers: "true"
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-dns-label-name: "{{ INGRESS_NGINX_AZURE_DNS_LABEL_NAME | default(None) }}"
+
 # Add annotation to include Azure load-balancer health probe request path
 INGRESS_NGINX_AZURE_LB_HEALTH_PROBE_CONFIG:
   controller:

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -49,6 +49,16 @@
     - install
     - update
 
+- name: Update INGRESS_NGINX_CONFIG to add Azure Application Gateway Config changes
+  set_fact:
+    INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG | combine(INGRESS_NGINX_AZURE_GATEWAY_CONFIG, recursive=True) }}"
+  when:
+    - PROVIDER == "azure"
+    - V4_CFG_APPLICATION_GATEWAY_ENABLED
+  tags:
+    - install
+    - update
+
 - name: Apply Mitigation for CVE-2021-25742
   tags:
     - install

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -274,6 +274,21 @@
         - tfstate.message_broker_primary_key is defined
         - tfstate.message_broker_primary_key.value|length > 0
         - V4_CFG_MESSAGE_BROKER_PASSWORD is not defined
+    - name: tfstate - azure application gateway enabled # noqa: name[casing]
+      set_fact:
+        V4_CFG_APPLICATION_GATEWAY_ENABLED: "{{ tfstate.app_gateway_enabled.value }}"
+      when:
+        - PROVIDER == "azure"
+        - tfstate.app_gateway_enabled is defined
+        - V4_CFG_APPLICATION_GATEWAY_ENABLED is not defined
+    - name: tfstate - Add azure application gateway public ip to LOADBALANCER_SOURCE_RANGES # noqa: name[casing]
+      set_fact:
+        LOADBALANCER_SOURCE_RANGES: "{{ LOADBALANCER_SOURCE_RANGES + [tfstate.app_gateway_frontend_ip.value + '/32'] }}"
+      when:
+        - PROVIDER == "azure"
+        - tfstate.app_gateway_frontend_ip is defined
+        - tfstate.app_gateway_frontend_ip.value|length > 0
+        - V4_CFG_APP_GATEWAY_IP is not defined
     - name: tfstate - set tfstate to empty string # noqa: name[casing]
       set_fact:
         tfstate: ""


### PR DESCRIPTION
## Changes:
New feature to support Azure Application Gateway with Azure WAF. `viya4-iac-azure` repo added new terraform azurerm resources to support this feature. For more details see `viya4-iac-azure` PR [#355](https://github.com/sassoftware/viya4-iac-azure/pull/355).

**Note:** There are related changes in the `viya4-iac-azure` repo to support these changes.
Also note, the work in SAS Viya products is still in progress so there might be more changes coming in this feature but this change should help the initial testing effort.

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|
|:----|:----|:----|:----|:----|:----|
|1|OOTB, `create_app_gateway = true`, `V4_CFG_APPLICATION_GATEWAY_ENABLED: true` `INGRESS_NGINX_AZURE_DNS_LABEL_NAME: "rp276t00a-ingress-nginx"` |Azure|fast:2020|1.26|ansible, DO: false|
|2|OOTB, `create_app_gateway = true`, `INGRESS_NGINX_AZURE_DNS_LABEL_NAME: "rp276t00a-ingress-nginx"`  |Azure|fast:2020|1.26|ansible, DO: true|
|3|OOTB,  `create_app_gateway = true`, `V4_CFG_APPLICATION_GATEWAY_ENABLED` and `INGRESS_NGINX_AZURE_DNS_LABEL_NAME` not set |Azure|fast:2020|1.26|ansible, DO: true|