### PR TITLE
feat: (IAC-1194) Update dependencies to resolve security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.26.8
+ARG kubectl_version=1.26.10
 
 WORKDIR /build
 
@@ -17,8 +17,8 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubect
 
 # Installation
 FROM baseline
-ARG helm_version=3.12.0
-ARG aws_cli_version=2.7.22
+ARG helm_version=3.12.2
+ARG aws_cli_version=2.13.33
 ARG gcp_cli_version=440.0.0-0
 
 # Add extra packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubect
 
 # Installation
 FROM baseline
-ARG helm_version=3.12.2
+ARG helm_version=3.13.2
 ARG aws_cli_version=2.13.33
 ARG gcp_cli_version=440.0.0-0
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -15,7 +15,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | rsync            | any         |
 | ~              | kubectl          | 1.25 - 1.27 |
 | ~              | Helm             | 3           |
-| pip3           | ansible          | 8.0.0       |
+| pip3           | ansible          | 8.6.0       |
 | pip3           | openshift        | 0.13.1      |
 | pip3           | kubernetes       | 26.1.0      |
 | pip3           | dnspython        | 2.3.0       |
@@ -48,7 +48,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.26.8 \
+	--build-arg kubectl_version=1.26.10 \
 	-t viya4-deployment .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible==8.0.0 # 2.10.7
+ansible==8.6.0 # 2.10.7
 openshift==0.13.1 # 0.12.0
 kubernetes==26.1.0 # 12.0.1
 dnspython==2.3.0 # 2.1.0
-docker==6.1.3
+docker==5.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ansible==8.0.0 # 2.10.7
 openshift==0.13.1 # 0.12.0
 kubernetes==26.1.0 # 12.0.1
 dnspython==2.3.0 # 2.1.0
-docker==5.0.3
+docker==6.1.3

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -5,4 +5,4 @@ collections:
   - name: community.docker
     version: 2.7.0
   - name: kubernetes.core
-    version: 2.4.0
+    version: 2.3.2

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -5,4 +5,4 @@ collections:
   - name: community.docker
     version: 2.7.0
   - name: kubernetes.core
-    version: 2.3.2
+    version: 2.4.0


### PR DESCRIPTION
### Changes

Updates 3rd party dependencies to resolve the security vulnerabilities. Users of the Dockerfile will automatically have these updated dependencies installed, and users who directly run this project on the host will need to update the dependencies themselves.

Update summary:
* `ansible:` 8.0.0 -> 8.6.0
  * No major version change, `ansible-core` updated from 2.15.0 -> 2.15.6
* `helm:` 3.12.0 -> 3.13.2

### Tests
Verified following scenario, see details in the internal ticket:

| Scenario | Provider | K8s Version | Order  | Cadence   | 
|----------|----------|-------------|--------|-----------|
| 1        | Azure     | v1.26.10    | ****** | fast:2020 | 