### PR TITLE
feat: (IAC-1266) (IAC-1186) Update kubectl to 1.27 and add support for ingress-nginx v1.9.X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.26.10
+ARG kubectl_version=1.27.9
 
 WORKDIR /build
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -408,7 +408,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.24.X, and version 4.9.0 is used for Kubernetes clusters whose version is >= 1.25.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.9.0` is used for Kubernetes clusters whose version is >= 1.25.X, and for Kubernetes clusters whose version is <= 1.24.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -408,7 +408,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.23.X, and version 4.7.1 is used for Kubernetes clusters whose version is >= 1.24.X. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version 4.3.0 is used for Kubernetes clusters whose version is <= 1.24.X, and version 4.9.0 is used for Kubernetes clusters whose version is >= 1.25.X. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | docker           | >=20.10.10  |
 | ~              | git              | any         |
 | ~              | rsync            | any         |
-| ~              | kubectl          | 1.25 - 1.27 |
+| ~              | kubectl          | 1.26 - 1.28 |
 | ~              | Helm             | 3           |
 | pip3           | ansible          | 8.6.0       |
 | pip3           | openshift        | 0.13.1      |
@@ -48,7 +48,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.26.10 \
+	--build-arg kubectl_version=1.27.9 \
 	-t viya4-deployment .
 ```
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -32,13 +32,13 @@ METRICS_SERVER_CONFIG:
 ## Ingress-nginx - Defaults
 ingressVersions:
   k8sMinorVersionCeiling:
-    value: 23
+    value: 24
     api:
       chartVersion: 4.3.0
   k8sMinorVersionFloor:
-    value: 24
+    value: 25
     api:
-      chartVersion: 4.7.1
+      chartVersion: 4.9.0
 
 ## Ingress-nginx - Ingress
 ##

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -31,11 +31,7 @@ METRICS_SERVER_CONFIG:
 
 ## Ingress-nginx - Defaults
 ingressVersions:
-  k8sMinorVersionCeiling:
-    value: 24
-    api:
-      chartVersion: 4.3.0
-  k8sMinorVersionFloor:
+  k8sMinorVersion:
     value: 25
     api:
       chartVersion: 4.9.0

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -25,11 +25,17 @@
       register: cluster_info
     - name: Set the default INGRESS_NGINX_CHART_VERSION based on K8s server minor version
       set_fact:
-        INGRESS_NGINX_CHART_VERSION: "{{ ingressVersions.k8sMinorVersionFloor.api.chartVersion if cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersionFloor.value,
-          'ge') else ingressVersions.k8sMinorVersionCeiling.api.chartVersion }}"
+        INGRESS_NGINX_CHART_VERSION: "{{ ingressVersions.k8sMinorVersion.api.chartVersion if cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersion.value,
+          'ge') else '' }}"
     - name: Output INGRESS_NGINX_CHART_VERSION
       debug:
         msg: "{{ INGRESS_NGINX_CHART_VERSION }}"
+    - name: Fail when INGRESS_NGINX_CHART_VERSION not set
+      fail:
+        msg: "INGRESS_NGINX_CHART_VERSION isn't set when K8s version is < 1.{{ingressVersions.k8sMinorVersion.value}}."
+      when:
+        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersion.value, 'lt')
+        - INGRESS_NGINX_CHART_VERSION == ""
 
 - name: Update INGRESS_NGINX_CONFIG to use NLB for AWS
   set_fact:
@@ -62,7 +68,7 @@
       set_fact:
         INGRESS_NGINX_CONFIG: "{{ INGRESS_NGINX_CONFIG | combine(INGRESS_NGINX_CVE_2021_25742_PATCH, recursive=True) }}"
       when:
-        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersionFloor.value, 'ge')
+        - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersion.value, 'ge')
         - INGRESS_NGINX_CHART_VERSION is version('4.0.10', ">=") or (INGRESS_NGINX_CHART_VERSION is version('3.40.0', ">=") and INGRESS_NGINX_CHART_VERSION is version('4.0.0',
           "<"))
 

--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -32,7 +32,7 @@
         msg: "{{ INGRESS_NGINX_CHART_VERSION }}"
     - name: Fail when INGRESS_NGINX_CHART_VERSION not set
       fail:
-        msg: "INGRESS_NGINX_CHART_VERSION isn't set when K8s version is < 1.{{ingressVersions.k8sMinorVersion.value}}."
+        msg: "INGRESS_NGINX_CHART_VERSION isn't set when K8s version is < 1.{{ ingressVersions.k8sMinorVersion.value }}."
       when:
         - cluster_info.version.server.kubernetes.minor is version(ingressVersions.k8sMinorVersion.value, 'lt')
         - INGRESS_NGINX_CHART_VERSION == ""


### PR DESCRIPTION
## Changes:
This PR updates the kubectl version to `1.27` and also updates the ingress-nginx version to 1.9.5 which supports the K8 versions: `1.28, 1.27, 1.26, 1.25`.

*Note:* The logic was updated to support the latest version of ingress by default. For any K8s version out of range for the given ingress version would now need to specify `INGRESS_NGINX_CHART_VERSION` to avoid error.

For example: The latest ingress Helm Chart Version is `4.9.0` which supports K8s range `1.28, 1.27, 1.26, 1.25`. For K8s version < 1.25.X, user needs to specify `INGRESS_NGINX_CHART_VERSION`. Not specifying the `INGRESS_NGINX_CHART_VERSION` will result in following error:
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "INGRESS_NGINX_CHART_VERSION isn't set when K8s version is < 1.25."
}
```
## Tests:
Verified following scenarios, please details in internal ticket:

| Scenario | Provider | kubernetes_version          | kubectl version |  cadence        | notes             |
|----------|----------|-----------------------------|--------|----------------|-------------------|
| 1        | Azure| 1.26  | 1.27.9          |  stable:2023.12 |                   |
| 2        | Azure| 1.27  | 1.27.9          | fast:2020 |                   |
| 3        | Azure| 1.28   | 1.27.9          |  fast:2020 | not yet supported by SAS Viya |
| 4        | AWS| 1.24   | 1.27.9          |  lts:2023.03 |  |