### PR TITLE
fix: (IAC-1335) Resolve: doc is missing path: "/spec/volumeClaimTemplates/0/spec/storageClassName" error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openshift==0.13.1 # 0.12.0
 kubernetes==26.1.0 # 12.0.1
 dnspython==2.3.0 # 2.1.0
 docker==5.0.3
+urllib3==1.26.18

--- a/roles/vdm/templates/transformers/sas-storageclass.yaml
+++ b/roles/vdm/templates/transformers/sas-storageclass.yaml
@@ -23,4 +23,4 @@ patch: |-
 target:
   group: apps
   kind: StatefulSet
-  annotationSelector: sas.com/component-name notin (sas-risk-cirrus-search,sas-workload-orchestrator,sas-data-agent-server-colocated)
+  annotationSelector: sas.com/component-name notin (sas-airflow,sas-risk-cirrus-search,sas-workload-orchestrator,sas-data-agent-server-colocated)


### PR DESCRIPTION
### Changes
- Avoid applying the sas-storage.yaml patchTransformer for the sas-airflow component so that DAC can successfully build the deployment manifest without encountering the fatal error indicated in the subject.
- Pin urllib3 to latest 1.26.x version. Use of urllib3>= 2.1.0 leads to the following error getting the orchestration tooling image when running DAC with a locally installed Ansible binary.

> TASK [vdm : Orchestration tooling - orchestration tooling image] ***************
> task path: ~/gitlab.sas.com/DOPE/ansible-marketplace/viya4-deployment/public/roles/orchestration-common/tasks/orchestration_tooling.yaml:153
> fatal: [localhost]: FAILED! => changed=false
>   msg: 'Error connecting: Error while fetching server API version: HTTPConnection.request() got an unexpected keyword argument ''chunked'''
> 

### Tests
| Provider |K8s | Deploy method | Order | Notes |
|-|-|-|-|-|
| AWS | 1.27 | ansible, installed in Python virtual env | includes SAS airflow component | DAC "baseline, viya, install" with DEPLOY=false runs to completion without error; `kustomize build . -o site.yaml` command to build manifest in the deployment folder is successful |
| AWS | 1.27 | ansible, installed in Python virtual env | includes SAS airflow component | DAC "baseline, viya, install" with DEPLOY=true runs to completion without error; sas-airflow requires additional configuration and is expected |

