### PR TITLE
feat: (IAC-1310) Dependency version update to resolve security vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubect
 
 # Installation
 FROM baseline
-ARG helm_version=3.13.2
+ARG helm_version=3.14.0
 ARG aws_cli_version=2.13.33
 ARG gcp_cli_version=460.0.0-0
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -14,7 +14,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | git              | any         |
 | ~              | rsync            | any         |
 | ~              | kubectl          | 1.26 - 1.28 |
-| ~              | Helm             | 3           |
+| ~              | Helm             | 3.14.0      |
 | pip3           | ansible          | 9.1.0       |
 | pip3           | openshift        | 0.13.1      |
 | pip3           | kubernetes       | 26.1.0      |

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -6,7 +6,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 
 | SOURCE         | NAME             | VERSION     |
 |----------------|------------------|-------------|
-| ~              | python           | >=3.9       |
+| ~              | python           | >=3.10       |
 | ~              | pip              | 3.x         |
 | ~              | unzip            | any         |
 | ~              | tar              | any         |
@@ -15,12 +15,12 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | rsync            | any         |
 | ~              | kubectl          | 1.26 - 1.28 |
 | ~              | Helm             | 3           |
-| pip3           | ansible          | 8.6.0       |
+| pip3           | ansible          | 9.1.0       |
 | pip3           | openshift        | 0.13.1      |
 | pip3           | kubernetes       | 26.1.0      |
 | pip3           | dnspython        | 2.3.0       |
 | pip3           | docker           | 5.0.3       |
-| ansible-galaxy | community.docker | 2.7.0       |
+| ansible-galaxy | community.docker | 2.7.8       |
 | ansible-galaxy | ansible.utils    | 2.3.0       |
 | ansible-galaxy | kubernetes.core  | 2.3.2       |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==8.6.0 # 2.10.7
+ansible==9.1.0 # 2.10.7
 openshift==0.13.1 # 0.12.0
 kubernetes==26.1.0 # 12.0.1
 dnspython==2.3.0 # 2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==9.1.0 # 2.10.7
+ansible==9.1.0 # 8.6.0 # 2.10.7
 openshift==0.13.1 # 0.12.0
 kubernetes==26.1.0 # 12.0.1
 dnspython==2.3.0 # 2.1.0

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -3,6 +3,6 @@ collections:
   - name: ansible.utils
     version: 2.3.0
   - name: community.docker
-    version: 2.7.0
+    version: 2.7.8
   - name: kubernetes.core
     version: 2.3.2


### PR DESCRIPTION
### Changes

Updates 3rd party dependencies to resolve security findings from our scanning tool. Consumers of the Dockerfile will automatically have these updated dependencies installed, and users who directly run this project on this host will need to update the dependencies themselves.

Update summary:

* `ansible` 8.6.0 -> 9.1.0
  * Not a major change, while the bundled collections are updated, `ansible-core` goes from 2.15.8 -> 2.16.1
  * https://github.com/ansible/ansible/blob/stable-2.15/changelogs/CHANGELOG-v2.15.rst
  * https://github.com/ansible/ansible/blob/stable-2.16/changelogs/CHANGELOG-v2.16.rst
  
* `community.docker` 2.7.0 -> 2.7.8
  * Not a major change, updated to latest available minor version
  * https://github.com/ansible-collections/community.docker/blob/stable-2/CHANGELOG.rst 

* `helm` 3.13.2 -> 3.14.0
  * Not a major change, updated to latest available minor version
  * https://github.com/helm/helm/releases/tag/v3.14.0

### Tests

| Scenario | Provider | K8s Version | Order  | Cadence   | Notes               |
|----------|----------|-------------|--------|-----------|----------------------|
| 1        | Azure | v1.27.9     | *** | fast:2020 |                  |
