### PR TITLE
fix: (IAC-1362) Fix the V4M_ROUTING Validation Task

### DIFF
--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -4,7 +4,7 @@
 ---
 - name: V4M - ensure supported value for V4M_ROUTING
   ansible.builtin.assert:
-    that: '{{ ["host-based", "path-based"] | intersect(V4M_ROUTING) | count == 1 }}'
+    that: '{{ ["host-based", "path-based"] | intersect([V4M_ROUTING]) | count == 1 }}'
     msg: >
       Invalid V4M_ROUTING value: {{ V4M_ROUTING }}
 


### PR DESCRIPTION
### Changes

Fix the `V4M - ensure supported value for V4M_ROUTING` task to that the intersect function has the correct input format.

#### Cause:
It looks like when we updated the `ansible` version from 9.1.0->8.6.0 this problem started appearing. That version bump causes the `ansible-core` version to go from 2.15->2.16.
Looking at the release notes for 2.16 it looks like there was a bug fix around set filters that changed its behavior. We are updating this function so we don't rely on its previous "bugged" behavior.
https://github.com/ansible/ansible/blob/stable-2.16/changelogs/CHANGELOG-v2.16.rst#v2-16-0

From CHANGELOG:
> * Set filters intersect, difference, symmetric_difference and union now always return a list, never a set. Previously, a set would be returned if the inputs were a hashable type such as str, instead of a collection, such as a list or tuple.
> * Set filters intersect, difference, symmetric_difference and union now use set operations when the given items are hashable. Previously, list operations were performed unless the inputs were a hashable type such as str, instead of a collection, such as a list or tuple.

**Example of behavior:**
ansible-core 2.15
```
ansible.builtin.debug: # working bugged behavior
  msg: '{{ ["host-based", "path-based"] | intersect(V4M_ROUTING) }}'
["host-based"] 

ansible.builtin.debug: # checking backwards compat
  msg: '{{ ["host-based", "path-based", "a"] | intersect([V4M_ROUTING]) }}'
["host-based"]  
```
ansible-core 2.16
```
ansible.builtin.debug: # causing our issue
  msg: '{{ ["host-based", "path-based",] | intersect(V4M_ROUTING) }}'
[]    

ansible.builtin.debug: # causing our issue
  msg: '{{ ["host-based", "path-based", "a"] | intersect(V4M_ROUTING) }}'
["a"]    

ansible.builtin.debug: # fix as list
  msg: '{{ ["host-based", "path-based", "a"] | intersect([V4M_ROUTING]) }}'
["host-based"]
```

### Tests

| Scenario | Provider | kubernetes_version   | order  | cadence   | notes                              |
|----------|----------|----------------------|--------|-----------|------------------------------------|
| 1        | GCP      | v1.27.10-gke.1152000 | *** | fast:2020 | logging,monitoring,viya-monitoring |
