### PR TITLE
feat: (IAC-1375) Edit Ingress Definitions for Alertmanager To Adapt Changes From Viya Monitoring

### DIFF
--- a/roles/monitoring/templates/host-based/user-values-prom-operator.yaml
+++ b/roles/monitoring/templates/host-based/user-values-prom-operator.yaml
@@ -17,6 +17,12 @@ prometheus:
     - {{ V4M_PROMETHEUS_FQDN }}
   prometheusSpec:
     externalUrl: "https://{{ V4M_PROMETHEUS_FQDN }}"
+    alertingEndpoints:
+      - name: v4m-alertmanager
+        port: http-web
+        scheme: https
+        tlsConfig:
+          insecureSkipVerify: true
     storageSpec:
       volumeClaimTemplate:
         spec:

--- a/roles/monitoring/templates/path-based/user-values-prom-operator.yaml
+++ b/roles/monitoring/templates/path-based/user-values-prom-operator.yaml
@@ -24,7 +24,7 @@ grafana:
 
 # Note that Prometheus and Alertmanager do not have any
 # authentication configured by default, exposing an
-# unauthenticated applicaton without other restrictions
+# unauthenticated application without other restrictions
 # in place is insecure.
 
 prometheus:
@@ -72,3 +72,10 @@ alertmanager:
   alertmanagerSpec:
     routePrefix: /alertmanager
     externalUrl: "https://{{ V4M_BASE_DOMAIN }}/alertmanager"
+    alertingEndpoints:
+      - name: v4m-alertmanager
+        port: http-web
+        pathPrefix: "/alertmanager"
+        scheme: https
+        tlsConfig:
+          insecureSkipVerify: true

--- a/roles/monitoring/templates/path-based/user-values-prom-operator.yaml
+++ b/roles/monitoring/templates/path-based/user-values-prom-operator.yaml
@@ -49,6 +49,13 @@ prometheus:
   prometheusSpec:
     routePrefix: /prometheus
     externalUrl: "https://{{ V4M_BASE_DOMAIN }}/prometheus"
+    alertingEndpoints:
+      - name: v4m-alertmanager
+        port: http-web
+        pathPrefix: "/alertmanager"
+        scheme: https
+        tlsConfig:
+          insecureSkipVerify: true
 
 alertmanager:
   # Disable default configuration of NodePort
@@ -72,10 +79,3 @@ alertmanager:
   alertmanagerSpec:
     routePrefix: /alertmanager
     externalUrl: "https://{{ V4M_BASE_DOMAIN }}/alertmanager"
-    alertingEndpoints:
-      - name: v4m-alertmanager
-        port: http-web
-        pathPrefix: "/alertmanager"
-        scheme: https
-        tlsConfig:
-          insecureSkipVerify: true


### PR DESCRIPTION
### Changes

Update the `Prometheus.prometheusSpec.alertingEndpoints` stanza in the `user-values-prom-operator.yaml` file for both our host-based and path-based templates. SAS Viya Monitoring has in an upcoming release that will be a breaking change for some users, the changes in the PR will be compatible with both the current configuration and the coming changes and prevent users from being impacted.

For additional details on the change from `viya4-monitoring-kubernetes` see the announcement underneath the notes for [Version 1.2.22 (13FEB2024)](https://github.com/sassoftware/viya4-monitoring-kubernetes/blob/main/CHANGELOG.md#version-1222-13feb2024). The release of their change is tentatively scheduled the 1.2.23 release (expected mid-March).


### Tests

| Scenario | Provider | K8s Version | V4M_ROUTING | Order  | Cadence   | Notes                                                                                                                |
|----------|----------|-------------|-------------|--------|-----------|----------------------------------------------------------------------------------------------------------------------|
| 1        | Azure    | v1.27.9     | host-based  | * | fast:2020 | OOTB + Logging & Monitoring                                                                                          |
| 2        | Azure    | v1.27.9     | path-based  | * | fast:2020 | OOTB + Logging & Monitoring                                                                                          |
| 3        | Azure    | v1.27.9     | host-based  | * | fast:2020 | Existing Logging & Monitoring apply updated configuration with  `Prometheus.prometheusSpec.alertingEndpoints` stanza |
| 4        | Azure    | v1.27.9     | path-based  | * | fast:2020 | Existing Logging & Monitoring apply updated configuration with  `Prometheus.prometheusSpec.alertingEndpoints` stanza |
