### PR TITLE
docs: (IAC-1236) Updated Dependencies.md file with correct versions

### DIFF
--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -23,7 +23,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | pip3           | urllib3          | 1.26.18     |
 | ansible-galaxy | community.docker | 3.8.0       |
 | ansible-galaxy | ansible.utils    | 3.1.0       |
-| ansible-galaxy | kubernetes.core  | 3.0.1       |
+| ansible-galaxy | kubernetes.core  | 3.0.0       |
 
 If you are using a provider based kubeconfig file created by viya4-iac-gcp:4.5.0 or newer, install these dependencies:
 | SOURCE         | NAME                    | VERSION     |


### PR DESCRIPTION
## Changes:
Dependencies.md file had an incorrect entry for `kubernetes.core` version. In the requirements.yaml, `kubernetes.core` version 3.0.0 is being installed and the doc was accidentally pointing to wrong version 3.0.1. This PR corrects that.
