### PR TITLE
fix: (IAC-1420) add debian revision to gcp_cli_version arg in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubect
 FROM baseline
 ARG helm_version=3.14.2
 ARG aws_cli_version=2.15.22
-ARG gcp_cli_version=464.0.0
+ARG gcp_cli_version=464.0.0-0
 
 # Add extra packages
 RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass skopeo rsync \


### PR DESCRIPTION
### Changes
Fix the `gcp_cli_version` argument value in the Dockerfile so that it has a Debian revision

### Tests

| Scenario | Provider | K8s Version                 | gcloud version | Order  | Cadence   | Notes                 |
|----------|----------|-----------------------------|----------------|--------|-----------|-----------------------|
| 1        | GCP      | 1.27 (v1.27.11-gke.1202000) | 464.0.0        | ****** | fast:2020 | OOTB - external image |

