### PR TITLE
feat: (IAC-1344) (IAC-1363) Add support for K8s 1.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.27.11
+ARG kubectl_version=1.28.7
 
 WORKDIR /build
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -386,7 +386,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | CLUSTER_AUTOSCALER_ENABLED | Whether to deploy cluster-autoscaler | bool | true | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://github.com/kubernetes/autoscaler/tree/master/charts) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_NAME| Cluster-autoscaler Helm chart name | string | cluster-autoscaler | false | | baseline |
-| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.36.0 is used. <br> See [Artifact Hub](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler) to determine application version| baseline |
+| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | 9.36.0 | false | Version `9.36.0` is used for Kubernetes clusters whose version is >= 1.25. For Kubernetes clusters whose version is <= 1.24 please set this variable to avoid errors. See [Artifact Hub](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler) to determine application version. | baseline |
 | CLUSTER_AUTOSCALER_CONFIG | Cluster-autoscaler Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_ACCOUNT | Cluster autoscaler AWS role ARN | string | | false | Required to enable cluster-autoscaler on AWS | baseline |
 | CLUSTER_AUTOSCALER_LOCATION |AWS region where Kubernetes cluster is running | string | us-east-1 | false | | baseline |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -386,7 +386,7 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. GCP GKE and Azur
 | CLUSTER_AUTOSCALER_ENABLED | Whether to deploy cluster-autoscaler | bool | true | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_URL | Cluster-autoscaler Helm chart URL | string | See [this document](https://github.com/kubernetes/autoscaler/tree/master/charts) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_CHART_NAME| Cluster-autoscaler Helm chart name | string | cluster-autoscaler | false | | baseline |
-| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.9.2 is used for Kubernetes clusters whose version is <= 1.24 <br> and version 9.34.1 is used for Kubernetes clusters whose version is >= 1.25 <br> See [Artifact Hub](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler) to determine application version| baseline |
+| CLUSTER_AUTOSCALER_CHART_VERSION | Cluster-autoscaler Helm chart version | string | "" | false | If left as "" (empty string), version 9.36.0 is used. <br> See [Artifact Hub](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler) to determine application version| baseline |
 | CLUSTER_AUTOSCALER_CONFIG | Cluster-autoscaler Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 | CLUSTER_AUTOSCALER_ACCOUNT | Cluster autoscaler AWS role ARN | string | | false | Required to enable cluster-autoscaler on AWS | baseline |
 | CLUSTER_AUTOSCALER_LOCATION |AWS region where Kubernetes cluster is running | string | us-east-1 | false | | baseline |
@@ -416,7 +416,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.9.0` is used for Kubernetes clusters whose version is >= 1.25.X, and for Kubernetes clusters whose version is <= 1.24.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.9.1` is used for Kubernetes clusters whose version is >= 1.25.X, and for Kubernetes clusters whose version is <= 1.24.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -49,7 +49,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.27.11 \
+	--build-arg kubectl_version=1.28.7 \
 	-t viya4-deployment .
 ```
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -164,7 +164,7 @@ CLUSTER_AUTOSCALER_NAME: cluster-autoscaler
 CLUSTER_AUTOSCALER_NAMESPACE: kube-system
 CLUSTER_AUTOSCALER_CHART_NAME: cluster-autoscaler
 CLUSTER_AUTOSCALER_CHART_URL: https://kubernetes.github.io/autoscaler
-CLUSTER_AUTOSCALER_CHART_VERSION: ""
+CLUSTER_AUTOSCALER_CHART_VERSION: 9.36.0
 CLUSTER_AUTOSCALER_ACCOUNT: null
 CLUSTER_AUTOSCALER_LOCATION: us-east-1
 CLUSTER_AUTOSCALER_CONFIG:
@@ -176,10 +176,6 @@ CLUSTER_AUTOSCALER_CONFIG:
       name: cluster-autoscaler
       annotations:
         eks.amazonaws.com/role-arn: "{{ CLUSTER_AUTOSCALER_ACCOUNT }}"
-
-autoscalerVersions:
-  api:
-    chartVersion: 9.36.0
 
 ## EBS CSI Driver
 EBS_CSI_DRIVER_ENABLED: true

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -35,7 +35,7 @@ ingressVersions:
   k8sMinorVersion:
     value: 25
     api:
-      chartVersion: 4.9.0
+      chartVersion: 4.9.1
 
 ## Ingress-nginx - Ingress
 ##
@@ -178,15 +178,8 @@ CLUSTER_AUTOSCALER_CONFIG:
         eks.amazonaws.com/role-arn: "{{ CLUSTER_AUTOSCALER_ACCOUNT }}"
 
 autoscalerVersions:
-  # Supports PodDisruptionBudget policy/v1beta1 default for K8s <=1.24
-  PDBv1beta1Support:
-    api:
-      chartVersion: 9.9.2
-      appVersion: 1.20.0
-  # Supports PodDisruptionBudget policy/v1beta1 default for K8s >=1.25
-  PDBv1Support:
-    api:
-      chartVersion: 9.34.1
+  api:
+    chartVersion: 9.36.0
 
 ## EBS CSI Driver
 EBS_CSI_DRIVER_ENABLED: true

--- a/roles/baseline/tasks/cluster-autoscaler.yaml
+++ b/roles/baseline/tasks/cluster-autoscaler.yaml
@@ -2,18 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Set the default CLUSTER_AUTOSCALER_CHART_VERSION if not specified
-  when:
-    - CLUSTER_AUTOSCALER_ENABLED
-    - CLUSTER_AUTOSCALER_CHART_VERSION|length == 0
-  tags:
-    - install
-    - update
-  block:
-    - name: Set the default CLUSTER_AUTOSCALER_CHART_VERSION based on K8s server minor version
-      set_fact:
-        CLUSTER_AUTOSCALER_CHART_VERSION: "{{ autoscalerVersions.api.chartVersion }}"
-
 - name: Deploy cluster-autoscaler
   kubernetes.core.helm:
     name: "{{ CLUSTER_AUTOSCALER_NAME }}"

--- a/roles/baseline/tasks/cluster-autoscaler.yaml
+++ b/roles/baseline/tasks/cluster-autoscaler.yaml
@@ -12,8 +12,7 @@
   block:
     - name: Set the default CLUSTER_AUTOSCALER_CHART_VERSION based on K8s server minor version
       set_fact:
-        CLUSTER_AUTOSCALER_CHART_VERSION: "{{ autoscalerVersions.PDBv1Support.api.chartVersion if K8S_VERSION | float >= 1.25 else autoscalerVersions.PDBv1beta1Support.api.chartVersion
-          }}"
+        CLUSTER_AUTOSCALER_CHART_VERSION: "{{ autoscalerVersions.api.chartVersion }}"
 
 - name: Deploy cluster-autoscaler
   kubernetes.core.helm:


### PR DESCRIPTION
## Changes:
This PR updates the default versions of ingress-nginx, cluster-autoscaler and kubectl to add support for K8s 1.29
- Default ingress-nginx chart version is updated to `4.9.1`
- Default cluster-autoscaler chart version is updated to `9.36.0`
- Default kubectl version is updated to `1.28.7`

Code to set default version of `CLUSTER_AUTOSCALER_CHART_VERSION` was simplified as K8s v1.24 is now out standard support for all the cloud providers. For users using K8s v1.24 to do LTS cadence version will now have to specify the CLUSTER_AUTOSCALER_CHART_VERSION in their `ansible-var.yaml` file. CONFIG_VARS.md file note is updated to guide user about the same.

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|Notes|
|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.27|docker, DO: false||
|2|OOTB|Azure|fast:2020|1.28|docker, DO: false| New default kubectl|
|3|OOTB|Azure|fast:2020|1.29|ansible, DO: true| Overwrite kubectl version in the DO|
|4|OOTB|AWS|fast:2020|1.29|ansible, DO: true| Overwrite kubectl version in the DO|