### PR TITLE
feat: (IAC-1424) Update Google Cloud CLI version to be in sync with viya4-iac-gcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubect
 FROM baseline
 ARG helm_version=3.14.2
 ARG aws_cli_version=2.15.22
-ARG gcp_cli_version=464.0.0-0
+ARG gcp_cli_version=471.0.0-0
 
 # Add extra packages
 RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass skopeo rsync \

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -28,7 +28,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 If you are using a provider based kubeconfig file created by viya4-iac-gcp:4.5.0 or newer, install these dependencies:
 | SOURCE         | NAME                    | VERSION     |
 |----------------|-------------------------|-------------|
-| ~              | gcloud                  | 464.0.0     |
+| ~              | gcloud                  | 471.0.0     |
 | ~              | gcloud-gke-auth-plugin  | >= 0.5.2    |
 
 Required project dependencies are generally pinned to known working or stable versions to ensure users have a smooth initial experience. In some cases it may be required to change the default version of a dependency. In such cases users are welcome to experiment with alternate versions, however compatibility may not be guaranteed.


### PR DESCRIPTION
### Changes

Updated the gcloud version to 471.0.0 to sync up with the `viya4-iac-gcp` project

### Tests

| Scenario | Provider | kubernetes_version  | Order  | Cadence   | Notes |
|----------|----------|---------------------|--------|-----------|-------|
| 1        | GCP      | v1.28.8-gke.1095000 | * | fast:2020 | OOTB  |
