### PR TITLE
docs: (IAC-1242) Update Documentation for V4_CFG_RWX_FILESTORE

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -89,7 +89,7 @@ Viya4-deployment uses the jump server to interact with the RWX filestore, which 
 ## Storage
 When `V4_CFG_MANAGE_STORAGE` is set to `true`, viya4-deployment creates the `sas` and `pg-storage` storage classes using the nfs-subdir-external-provisioner Helm chart. If a jump server is used, viya4-deployment uses that server to create the folders for the `astores`, `bin`, `data` and `homes` RWX Filestore NFS paths that are outlined below in the [RWX Filestore](#rwx-filestore) section.
 
-When `V4_CFG_MANAGE_STORAGE` is set to `false`, viya4-deployment does not create the `sas` or `pg-storage` storage classes for you. In addition, viya4-deployment does not create or manage the RWX Filestore NFS paths. Before you run the SAS Viya deployment, you must set the values for `V4_CFG_RWX_FILESTORE_ASTORES_PATH`, `V4_CFG_RWX_FILESTORE_BIN_PATH`, `V4_CFG_RWX_FILESTORE_DATA_PATH` and `V4_CFG_RWX_FILESTORE_HOMES_PATH` to specify existing NFS folder locations. The viya4-deployment user can create the required NFS folders from the jump server before starting the deployment. Recommended attribute settings for each folder are as follows:
+When `V4_CFG_MANAGE_STORAGE` is set to `false`, viya4-deployment does not create the `sas` or `pg-storage` storage classes for you. In addition, viya4-deployment does not create or manage the RWX Filestore NFS paths. Before you run the SAS Viya deployment, you must set the values for `V4_CFG_RWX_FILESTORE_DATA_PATH` and `V4_CFG_RWX_FILESTORE_HOMES_PATH` to specify existing NFS folder locations. The viya4-deployment user can create the required NFS folders from the jump server before starting the deployment. Recommended attribute settings for each folder are as follows:
 - **filemode**: `0777`
 - **group**: the equivalent of `nogroup` for your operating system
 - **owner**: `nobody`
@@ -105,8 +105,6 @@ When `V4_CFG_MANAGE_STORAGE` is set to `false`, viya4-deployment does not create
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | V4_CFG_RWX_FILESTORE_ENDPOINT | NFS IP address or host name | string | | false | | baseline, viya |
 | V4_CFG_RWX_FILESTORE_PATH | NFS export path | string | /export | false | | baseline, viya |
-| V4_CFG_RWX_FILESTORE_ASTORES_PATH | NFS path to astores directory | string | <V4_CFG_RWX_FILESTORE_PATH>/\<NAMESPACE>/astores | false | | viya |
-| V4_CFG_RWX_FILESTORE_BIN_PATH | NFS path to bin directory | string | <V4_CFG_RWX_FILESTORE_PATH>/\<NAMESPACE>/bin | false | | viya |
 | V4_CFG_RWX_FILESTORE_DATA_PATH | NFS path to data directory | string | <V4_CFG_RWX_FILESTORE_PATH>/\<NAMESPACE>/data | false | | viya |
 | V4_CFG_RWX_FILESTORE_HOMES_PATH | NFS path to homes directory | string | <V4_CFG_RWX_FILESTORE_PATH>/\<NAMESPACE>/homes | false | | viya |
 

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -26,6 +26,8 @@ V4_CFG_RWX_FILESTORE_ENDPOINT: null
 V4_CFG_RWX_FILESTORE_PATH: /export
 V4_CFG_RWX_FILESTORE_DATA_PATH: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/{{ NAMESPACE }}/data"
 V4_CFG_RWX_FILESTORE_HOMES_PATH: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/{{ NAMESPACE }}/homes"
+# The two variables below are not used in updating any template files or used in any ansible tasks
+# They have been removed from CONFIG-VARS.md, if they are used in the future add them back.
 V4_CFG_RWX_FILESTORE_ASTORES_PATH: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/{{ NAMESPACE }}/astores"
 V4_CFG_RWX_FILESTORE_BIN_PATH: "{{ V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') }}/{{ NAMESPACE }}/bin"
 


### PR DESCRIPTION
### Changes

Remove `V4_CFG_RWX_FILESTORE_ASTORES_PATH` & `V4_CFG_RWX_FILESTORE_BIN_PATH` from `CONFIG-VARS.md` since the variables are not used at this time 

### Tests


| Scenario | Provider | K8s Version | order  | cadence   | Notes                                                            |
|----------|----------|-------------|--------|-----------|------------------------------------------------------------------|
| 1        | Azure    | v1.28.5     | ****** | fast:2020 | Set the `V4_CFG_RWX_FILESTORE_*` variables and checked for usage |