### PR TITLE
fix: (PSKD-398) Update v4m storage class deletion behavior

### DIFF
--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -50,6 +50,30 @@
   tags:
     - cluster-logging
 
+- name: V4M - check if storage class is being used
+  ansible.builtin.shell: |
+    kubectl --kubeconfig {{ KUBECONFIG }} get pv --output=custom-columns='PORT:.spec.storageClassName' | grep -o v4m | wc -l
+  register: sc_users
+  when:
+    - PROVIDER is not none
+    - PROVIDER in ["azure","aws","gcp"]
+    - V4_CFG_MANAGE_STORAGE is not none
+    - V4_CFG_MANAGE_STORAGE|bool
+  tags:
+    - uninstall
+
+- name: V4M - storageclass uninstall status
+  debug:
+    msg: "{{ sc_users.stdout }} Persistent Volumes still referring to the v4m Storage Class, skipping deletion"
+  when:
+    - PROVIDER is not none
+    - PROVIDER in ["azure","aws","gcp"]
+    - V4_CFG_MANAGE_STORAGE is not none
+    - V4_CFG_MANAGE_STORAGE|bool
+    - sc_users.stdout | int > 0
+  tags:
+    - uninstall
+
 - name: V4M - remove storageclass
   kubernetes.core.k8s:
     kubeconfig: "{{ KUBECONFIG }}"
@@ -60,5 +84,6 @@
     - PROVIDER == "azure"
     - V4_CFG_MANAGE_STORAGE is not none
     - V4_CFG_MANAGE_STORAGE|bool
+    - sc_users.stdout | int == 0
   tags:
     - uninstall

--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -81,7 +81,7 @@
     src: "{{ role_path }}/files/{{ PROVIDER }}-storageclass.yaml"
   when:
     - PROVIDER is not none
-    - PROVIDER == "azure"
+    - PROVIDER in ["azure","aws","gcp"]
     - V4_CFG_MANAGE_STORAGE is not none
     - V4_CFG_MANAGE_STORAGE|bool
     - sc_users.stdout | int == 0

--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -64,7 +64,7 @@
 
 - name: V4M - storageclass uninstall status
   ansible.builtin.debug:
-    msg: "{{ sc_users.stdout }} Persistent Volumes still referring to the v4m Storage Class, skipping deletion"
+    msg: "Persistent Volumes still referring to the v4m Storage Class, skipping deletion"
   when:
     - PROVIDER is not none
     - PROVIDER in ["azure","aws","gcp"]

--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -63,7 +63,7 @@
     - uninstall
 
 - name: V4M - storageclass uninstall status
-  debug:
+  ansible.builtin.debug:
     msg: "{{ sc_users.stdout }} Persistent Volumes still referring to the v4m Storage Class, skipping deletion"
   when:
     - PROVIDER is not none


### PR DESCRIPTION
### Changes

Updated the uninstallation behavior when `V4_CFG_MANAGE_STORAGE:true` & `PROVIDER in ["azure","aws","gcp"]` so that the v4m storage class will not be removed if there are still PVs using it. If no PVs are making use of the v4m sc then it will also be removed. This prevents the v4m SC from being removed if a user just uninstalls only logging or only monitoring.


### Tests

| Scenario | Provider | Kubernetes Version   | Install                                                  | Uninstall 1                                                | Uninstall 2                                                    |
|----------|----------|----------------------|----------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------|
| 1        | Azure    | v1.28.9              | baseline,viya,cluster-logging,cluster-monitoring,install | uninstalling just cluster-logging did not remove the SC    | uninstalling just cluster-monitoring afterwards removes the SC |        
| 2        | AWS      | v1.29.5-eks-1de2ab1  | baseline,viya,cluster-logging,cluster-monitoring,install | uninstalling just cluster-monitoring did not remove the SC | uninstalling just cluster-logging afterwards removes the SC    |        
| 3        | GCP      | v1.28.11-gke.1019000 | baseline,viya,cluster-logging,cluster-monitoring,install | uninstalling just cluster-monitoring did not remove the SC | uninstalling just cluster-logging afterwards removes the SC    |