### PR TITLE
feat: add support for K8S 1.30 (PSKD-518)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline as tool_builder
-ARG kubectl_version=1.28.7
+ARG kubectl_version=1.29.7
 
 WORKDIR /build
 

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | docker           | >=25.0.3    |
 | ~              | git              | any         |
 | ~              | rsync            | any         |
-| ~              | kubectl          | 1.26 - 1.28 |
+| ~              | kubectl          | 1.28 - 1.30 |
 | ~              | Helm             | 3.14.2      |
 | pip3           | ansible          | 9.2.0       |
 | pip3           | openshift        | 0.13.2      |
@@ -49,7 +49,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.28.7 \
+	--build-arg kubectl_version=1.29.7 \
 	-t viya4-deployment .
 ```
 


### PR DESCRIPTION
Updated files necessary to change kubectl version to 1.29.7 in support of K8S 1.30.

## Changes:
This PR updates the default version of kubectl to add support for K8s 1.30
- Default kubectl version is updated to `1.29.7`

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|Notes|
|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|stable:2024.07|1.28|docker, DO: false||
|2|OOTB|Azure|stable:2024.07|1.29|docker, DO: false| New default kubectl|
|3|OOTB|Azure|stable:2024.07|1.30|ansible, DO: true| Overwrite kubectl version in the DO|