### PR TITLE
feat: add annotation for external database (PSKD-407)

### DIFF
--- a/roles/vdm/templates/transformers/dataserver-transformer.yaml
+++ b/roles/vdm/templates/transformers/dataserver-transformer.yaml
@@ -5,6 +5,10 @@ kind: PatchTransformer
 metadata:
   name: {{ dataserver_name }}-dataserver-transformer
 patch: |-
+  - op: add
+    path: "/metadata/annotations/sas.com~1database-server-location"
+    value: external # Identifies that database server is external
+
   - op: replace
     path: /spec/databases/0/name
     value: {{ db }}


### PR DESCRIPTION

## Changes:
This PR adds an annotation to deployments that are using an external postgres database.  The presence of the annotation will gate behaviour of the data server operator.

## Tests:
Verified following scenarios

|Scenario|Task|Provider|Cadence|kubernetes_version|Database|Notes|
|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|stable:2024.07|1.28|default: external| Annotation appears in sasdeployment.yaml manifest|
|2|OOTB|Azure|stable:2024.07|1.29|default: internal| Annotation does NOT appear in sasdeployment.yaml manifest|
