### PR TITLE
feat: (PSKD-503) Update DaC ingress-nginx version for K8s 1.30 support

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -413,7 +413,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.9.1` is used for Kubernetes clusters whose version is >= 1.25.X, and for Kubernetes clusters whose version is <= 1.24.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.11.1` is used for Kubernetes clusters whose version is >= 1.26.X, and for Kubernetes clusters whose version is <= 1.25.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -33,9 +33,9 @@ METRICS_SERVER_CONFIG:
 ## Ingress-nginx - Defaults
 ingressVersions:
   k8sMinorVersion:
-    value: 25
+    value: 26
     api:
-      chartVersion: 4.9.1
+      chartVersion: 4.11.1
 
 ## Ingress-nginx - Ingress
 ##


### PR DESCRIPTION
This PR updates the ingress-nginx version to `v1.11.1` which supports the K8 versions: 1.30, 1.29 1.28, 1.27 and 1.26.

| Scenario | Cloud Provider | Cadence             | Ingress-NGINX version | Kubernetes version | Notes                                      |
|----------|----------------|---------------------|-----------------------|--------------------|--------------------------------------------|
| 1        | AWS            | stable:2024.07 R/P  | v1.11.1               | v1.29              | Successful deployment, all pods Running and stable |
| 2        | Azure          | stable:2024.07 R/P  | v1.11.1                | v1.28              | Successful deployment, all pods Running and stable |
| 3        | Azure          | n/a                 | v1.11.1               | v1.30              | Verified that the expected versions of ingress-nginx v1.11.1 was installed via "baseline,install" tasks, ingress-nginx pod initialized successfully on k8s v1.30 and is Running and stable