### PR TITLE
fix: (PSKD-640) Fixed file path for Workload Orchestrator

### DIFF
--- a/roles/vdm/tasks/workload_orchestrator.yaml
+++ b/roles/vdm/tasks/workload_orchestrator.yaml
@@ -23,7 +23,8 @@
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
     existing: "{{ vdm_overlays }}"
     add:
-      - { transformers: examples/sas-workload-orchestrator/enable-disable/sas-workload-orchestrator-disable-patch-transformer.yaml, min: "2023.08", vdm: false }
+      - { transformers: examples/sas-workload-orchestrator/enable-disable/sas-workload-orchestrator-disable-patch-transformer.yaml, min: "2023.08", max: "2024.06", vdm: false }
+      - { transformers: overlays/sas-workload-orchestrator/enable-disable/sas-workload-orchestrator-disable-patch-transformer.yaml, min: "2024.07", vdm: false }
   when:
     - not V4_WORKLOAD_ORCHESTRATOR_ENABLED
   tags:


### PR DESCRIPTION
# Changes:
Starting SAS Viya cadence 2024.07 the SAS Workload Orchestrator Configuration file location changed. This PR updates the path based on specified cadence version.

# Tests:
Verified following scenarios with `V4_DEPLOYMENT_OPERATOR_ENABLED: false` and `V4_WORKLOAD_ORCHESTRATOR_ENABLED: false`.
|Scenario|Task|Provider|Cadence|Deploy method|
|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|ansible|
|2|OOTB|Azure|stable:2024.06|ansible|
|3|OOTB|Azure|lts:2023.03|ansible|