### PR TITLE
580:  search for hidden files in cacerts dir

### DIFF
--- a/roles/vdm/tasks/tls.yaml
+++ b/roles/vdm/tasks/tls.yaml
@@ -164,6 +164,7 @@
       find:
         paths: "{{ DEPLOY_DIR }}/site-config/vdm/security/cacerts/"
         depth: 2
+        hidden: true
       register: V4_CFG_TLS_TRUSTED_CA_CERT_FILES
     - name: TLS - add customer provided ca cert generator
       overlay_facts:


### PR DESCRIPTION
Fixes issue 580 by adding `hidden: true` to the find module to restore v4_cfg_tls_trusted_ca_certs  functionality