### PR TITLE
feat: (PSKD-813) add support for K8s 1.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline AS tool_builder
-ARG kubectl_version=1.29.8
+ARG kubectl_version=1.30.6
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG kubectl_version=1.30.6
 
 WORKDIR /build
 
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$kubectl_version/bin/linux/amd64/kubectl && chmod 755 ./kubectl
+RUN curl -sLO https://dl.k8s.io/release/v$kubectl_version/bin/linux/amd64/kubectl && chmod 755 ./kubectl
 
 # Installation
 FROM baseline

--- a/docs/user/Dependencies.md
+++ b/docs/user/Dependencies.md
@@ -13,7 +13,7 @@ The following list details our dependencies and versions (~ indicates multiple p
 | ~              | docker           | >=25.0.3     |
 | ~              | git              | any          |
 | ~              | rsync            | any          |
-| ~              | kubectl          | 1.28 - 1.30  |
+| ~              | kubectl          | 1.29 - 1.31  |
 | ~              | Helm             | 3.16.2       |
 | pip3           | ansible          | 10.5.0       |
 | pip3           | openshift        | 0.13.2       |
@@ -49,7 +49,7 @@ As described in the [Docker Installation](./DockerUsage.md) section add addition
 ```bash
 # Override kubectl version
 docker build \
-	--build-arg kubectl_version=1.29.8 \
+	--build-arg kubectl_version=1.30.6 \
 	-t viya4-deployment .
 ```
 


### PR DESCRIPTION
Update files necessary to change kubectl version to 1.30.6 in support of K8S 1.31.

## Changes:
This PR updates the default version of kubectl to add support for K8s 1.31
- Default kubectl version is updated to `1.30.6`

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Provider|kubernetes_version|Order|Cadence|Notes|
|:----|:----|:----|:----|:----|:----|
|1|Azure|1.31.2|***|fast:2020|OOTB, external Postgres Database, front-door TLS. Overwrite kubectl version in DO|
|2|GCP|1.29.10|***|fast:2020|OOTB, external Postgres Database, front-door TLS. DO: true|
|3|AWS|1.30.6|***|fast:2020|Used local tooling. Internal Postgres Database, full-stack TLS. DO: false|