### PR TITLE
feat: (PSKD-881) Update Skopeo Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git j
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-
 COPY --from=tool_builder /build/kubectl /usr/local/bin/kubectl
 COPY --from=golang /go/skopeo/bin/skopeo.linux.386 /usr/local/bin/skopeo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,12 @@ WORKDIR /build
 
 RUN curl -sLO https://dl.k8s.io/release/v$kubectl_version/bin/linux/amd64/kubectl && chmod 755 ./kubectl
 
-# Build Skopeo from source 
-# FROM golang:1.23 AS golang
-# ARG SKOPEO_VERSION=release-1.16
-# RUN apt-get update && apt-get install --no-install-recommends -y libgpgme-dev libassuan-dev libbtrfs-dev pkg-config \
-#   && git clone https://github.com/containers/skopeo.git -b release-1.16 \
-#   && DISABLE_DOCS=1 make -C skopeo/
+# Build Skopeo from source since the version in the apt repository is outdated
+FROM golang:alpine3.20 AS golang
+ARG SKOPEO_VERSION=release-1.16
+RUN apk update && apk add git build-base containers-common bash btrfs-progs-dev glib-dev go go-md2man gpgme-dev libselinux-dev linux-headers lvm2-dev ostree-dev \
+  && git clone https://github.com/containers/skopeo.git -b $SKOPEO_VERSION \
+  && DISABLE_DOCS=1 make -C skopeo bin/skopeo.linux.386
 
 # Installation
 FROM baseline
@@ -29,7 +29,7 @@ ARG aws_cli_version=2.17.58
 ARG gcp_cli_version=496.0.0-0
 
 # Add extra packages
-RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass rsync libgpgme-dev \
+RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass rsync \
   && rm -f /etc/ssh/ssh_host_rsa_key && rm -f /etc/ssh/ssh_host_ecdsa_key && rm -f /etc/ssh/ssh_host_ed25519_key \
   && curl -ksLO https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 755 get-helm-3 \
   && ./get-helm-3 --version v$helm_version --no-sudo \
@@ -44,16 +44,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git j
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt-get update && apt-get install --no-install-recommends -y google-cloud-cli:amd64=${gcp_cli_version} \
   && apt-get install --no-install-recommends -y google-cloud-sdk-gke-gcloud-auth-plugin \
-  # Skopeo
-  && echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] http://archive.ubuntu.com/ubuntu noble noble-updates main universe" | tee -a /etc/apt/sources.list.d/ubuntu-noble.list \
-  && apt-get update && apt-get install -y skopeo -t noble \    
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 
-
 COPY --from=tool_builder /build/kubectl /usr/local/bin/kubectl
-# COPY --from=golang /go/skopeo/bin/skopeo /usr/local/bin/skopeo
+COPY --from=golang /go/skopeo/bin/skopeo.linux.386 /usr/local/bin/skopeo
 
 WORKDIR /viya4-deployment/
 COPY . /viya4-deployment/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -sLO https://dl.k8s.io/release/v$kubectl_version/bin/linux/amd64/kubect
 # Build Skopeo from source since the version in the apt repository is outdated
 FROM golang:alpine3.20 AS golang
 ARG SKOPEO_VERSION=release-1.16
-RUN apk update && apk add git build-base containers-common bash btrfs-progs-dev glib-dev go go-md2man gpgme-dev libselinux-dev linux-headers lvm2-dev ostree-dev \
+RUN apk add --no-cache git build-base containers-common bash btrfs-progs-dev glib-dev go go-md2man gpgme-dev libselinux-dev linux-headers lvm2-dev ostree-dev \
   && git clone https://github.com/containers/skopeo.git -b $SKOPEO_VERSION \
   && DISABLE_DOCS=1 make -C skopeo bin/skopeo.linux.386
 

--- a/roles/orchestration-common/tasks/orchestration_tooling.yaml
+++ b/roles/orchestration-common/tasks/orchestration_tooling.yaml
@@ -75,7 +75,7 @@
 # if the parsed creds contain symbols. This is expected and required to avoid Jinja2 templating issues.
 - name: Orchestration tooling - Download orchestration tooling image
   command: |
-    skopeo copy docker://{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }} oci-archive:{{ ORCHESTRATION_TOOLING_ARCHIVE }} --src-creds {{ ORCHESTRATION_CR_USER | string }}:{{ ORCHESTRATION_CR_PASSWORD | string }}
+    skopeo copy docker://{{ V4_CFG_CR_HOST }}/{{ ORCHESTRATION_IMAGE }} oci-archive:{{ ORCHESTRATION_TOOLING_ARCHIVE }} --src-creds {{ ORCHESTRATION_CR_USER | string }}:{{ ORCHESTRATION_CR_PASSWORD | string }} --insecure-policy
   when:
     - deployment_tooling == "docker"
   tags:


### PR DESCRIPTION
## Changes:
This PR changes how the Dockerfile installs skopeo. The version in the apt repository is outdated, so this will build it from the source and copy it into the Docker image.

Note: Skopeo is only used by the Docker image. Consumers that don't use the Docker image will be unaffected.

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Provider|Order|Cadence|Notes|
|:----|:----|:----|:----|:----|
|1|Azure|***|fast:2020|OOTB, internal DB. DO: true|
|2|GCP|***|fast:2020|OOTB, internal DB. DO: false|
|3|GCP|***|fast:2020|Used local tooling. Skopeo is only used by the Docker Image, so this is unaffected.|