### PR TITLE
feat: (PSKD-792) Update default version of cert-manager to v1.16.2

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -374,7 +374,7 @@ Notes:
 | CERT_MANAGER_NAMESPACE | cert-manager Helm installation namespace | string | cert-manager | false | | baseline |
 | CERT_MANAGER_CHART_URL | cert-manager Helm chart URL | string | https://charts.jetstack.io/ | false | | baseline |
 | CERT_MANAGER_CHART_NAME| cert-manager Helm chart name | string | cert-manager| false | | baseline |
-| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.14.4 | false | | baseline |
+| CERT_MANAGER_CHART_VERSION | cert-manager Helm chart version | string | 1.16.2 | false | | baseline |
 | CERT_MANAGER_CONFIG | cert-manager Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | | baseline |
 
 Notes:

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -14,9 +14,10 @@ CERT_MANAGER_NAME: cert-manager
 CERT_MANAGER_NAMESPACE: cert-manager
 CERT_MANAGER_CHART_NAME: cert-manager
 CERT_MANAGER_CHART_URL: https://charts.jetstack.io/
-CERT_MANAGER_CHART_VERSION: 1.14.4
+CERT_MANAGER_CHART_VERSION: 1.16.2
 CERT_MANAGER_CONFIG:
-  installCRDs: "true"
+  crds:
+    enabled: true
   extraArgs:
     - --enable-certificate-owner-ref=true
 


### PR DESCRIPTION
### Changes
- Update default version of cert-manager installed to v1.16.2
- Replaced deprecated `installCRDs` Helm option value with supported option

### Tests
| Scenario | Provider | K8S version | DAC method | Installed CERT-MANAGER_CHART_VERSION | CERT_MANAGER_CHART_VERSION | order | cadence | Notes |
|----------|----------|-------------|------------|-------------------------------------|-----------------------------|-------|---------|-------|
|1|Azure|1.29|docker|1.14.4|1.16.2|n/a|n/a|Running DaC with the default version of 1.16.2 and "baseline,install" results in a successful cert-manager upgrade to version v1.16.2|
| 2        | AWS      | 1.30        | docker     | None                                | 1.16.2                      | *     | n/a     | Resulting error message. `installCRDs` value is the incorrect type, it should be true, not "true". That value is deprecated for v1.16.2 so removing and replacing it with crds.enabled option per cert-manager values.yaml file. |
| 3        | AWS      | 1.30        | docker     | None                                | 1.16.2                      | *     | n/a     | Altered the value for installCRDs to a boolean from string, Result: version 1.16.2 was successfully installed with this warning message stating that the `installCRDs` Helm option is deprecated. Updating the configuration to use crds.enabled options instead, retest install with change for Scenario 4: |
| 4        | AWS      | 1.30        | local      | None                                | 1.16.2                      | *     | n/a     | Successful v1.16.2 install. Updated the configuration to use crds.enabled Helm options as below instead of `installCRDs` which has been deprecated |
| 5        | Azure    | 1.29        | docker     | None                                | 1.16.2                      | *     | 2024.11 | With updated configuration to use crds.enabled Helm options cert-manager v1.16.2 installed successfully. Successful deployment of stable:2024.11 cadence. Successful login to Viya application and navigation to SAS Studio which created a compute context. |