### PR TITLE
feat: (PSKD-957) ingress-nginx configmap changes for v1.12+

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -61,6 +61,8 @@ INGRESS_NGINX_CONFIG:
       use-forwarded-headers: "false"
       hsts-max-age: "63072000"
       hide-headers: Server,X-Powered-By
+      annotations-risk-level: "Critical"
+      strict-validate-path-type: "false"
     tcp: {}
     udp: {}
     lifecycle:


### PR DESCRIPTION
### Changes
- Add two config map values to maintain the default values they had prior to `ingress-nginx` v1.12
- `ingress-nginx` v1.12.0 has changed the defaults for those two config map values, the values required by the Viya platform differ from the new defaults.

### Tests
To be performed when `ingress-nginx` v1.12.0 is released.