### PR TITLE
feat: (PSKD-1006) Use ingress-nginx v1.12 for K8s 1.31 support

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -419,7 +419,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.11.1` is used for Kubernetes clusters whose version is >= 1.26.X, and for Kubernetes clusters whose version is <= 1.25.X please set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.12.0` is used for Kubernetes clusters whose version is >= 1.26.X, for Kubernetes clusters whose version is <= 1.25.X you must set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -419,7 +419,7 @@ The EBS CSI driver is currently only used for kubernetes v1.23 or later AWS EKS 
 | INGRESS_NGINX_NAMESPACE | NGINX Ingress Helm installation namespace | string | ingress-nginx | false | | baseline |
 | INGRESS_NGINX_CHART_URL | NGINX Ingress Helm chart URL | string | See [this document](https://kubernetes.github.io/ingress-nginx) for more information. | false | | baseline |
 | INGRESS_NGINX_CHART_NAME | NGINX Ingress Helm chart name | string | ingress-nginx | false | | baseline |
-| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.12.0` is used for Kubernetes clusters whose version is >= 1.26.X, for Kubernetes clusters whose version is <= 1.25.X you must set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
+| INGRESS_NGINX_CHART_VERSION | NGINX Ingress Helm chart version | string | "" | false | If left as "" (empty string), version `4.12.0` is used for Kubernetes clusters whose version is >= 1.28.X, for Kubernetes clusters whose version is <= 1.27.X you must set this variable to avoid errors. See [Supported Versions table](https://github.com/kubernetes/ingress-nginx/?tab=readme-ov-file#supported-versions-table) for the supported versions list. | baseline |
 | INGRESS_NGINX_CONFIG | NGINX Ingress Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### Metrics Server

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -34,7 +34,7 @@ METRICS_SERVER_CONFIG:
 ## Ingress-nginx - Defaults
 ingressVersions:
   k8sMinorVersion:
-    value: 26
+    value: 28
     api:
       chartVersion: 4.12.0
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -36,7 +36,7 @@ ingressVersions:
   k8sMinorVersion:
     value: 26
     api:
-      chartVersion: 4.11.1
+      chartVersion: 4.12.0
 
 ## Ingress-nginx - Ingress
 ##


### PR DESCRIPTION
### Changes
- Update the default version of the `ingress-nginx` Helm chart to use v4.12.0 for K8s >= v1.28 in order to support K8s 1.31
- Update the default for `INGRESS_NGINX_CHART_VERSION` in CONFIG-VARS.md file to be 4.12.0

### Tests

| Scenario | Provider | K8s version | ingress-nginx chart version | Cadence       | relevant ingress-nginx config map values                          | Notes                                                                 |
|----------|----------|-------------|-----------------------------|---------------|-------------------------------------------------------------------|-----------------------------------------------------------------------|
| 1        | Azure    | 1.30.6      | (default) 4.12.0            | stable:2024.12| annotations-risk-level: Critical                                  | Single expected configMap value set for ingress-nginx v1.12.0 at stable:2024.12 cadence                     |
| 2        | Azure    | 1.30.6      | (configured) 4.11.4         | stable:2024.12| none                                                              | No additional ingress-nginx configMap values set for ingress-nginx v1.11.4 at stable:2024.12, matches results for PSKD-1087 |
| 3        | Azure    | 1.30.6      | (default) 4.12.0            | stable:2024.11| strict-validate-path-type: 'false'; annotations-risk-level: Critical| Both expected configMap values set for ingress-nginx v1.12.0 at stable:2024.11, matches results for PSKD-1087 |
| 4        | AWS      | 1.30.7      | (default) 4.12.0            | stable:2024.12| annotations-risk-level: Critical                                  | Single expected configMap value set for ingress-nginx v1.12.0 at stable:2024.12, matches results for PSKD-1087; Successful Viya4 deployment and viya_admin login to fqdn deploy.aws1.devops.unx.sas.com|
