### PR TITLE
chore: (PSKD-1406) Dependency Version Bumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get upgrade -y \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 FROM baseline AS tool_builder
-ARG kubectl_version=1.30.6
+ARG kubectl_version=1.30.10
 
 WORKDIR /build
 
@@ -25,8 +25,8 @@ RUN apk add --no-cache git build-base containers-common bash btrfs-progs-dev gli
 # Installation
 FROM baseline
 ARG helm_version=3.17.1
-ARG aws_cli_version=2.17.58
-ARG gcp_cli_version=496.0.0-0
+ARG aws_cli_version=2.24.16
+ARG gcp_cli_version=513.0.0-0
 
 # Add extra packages
 RUN apt-get update && apt-get install --no-install-recommends -y gzip wget git jq ssh sshpass rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache git build-base containers-common bash btrfs-progs-dev gli
 
 # Installation
 FROM baseline
-ARG helm_version=3.16.2
+ARG helm_version=3.17.1
 ARG aws_cli_version=2.17.58
 ARG gcp_cli_version=496.0.0-0
 


### PR DESCRIPTION
We're bumping the helm version to address a high security vulnerability found in the prisma scan. The vulnerability found is with golang.org/x/net v0.26.0. Using v3.17.1 version of helm gets us to v0.33.0 of golang.org/x/net where the vulnerability has been addressed.

We're also refreshing the versions of other binaries included in the image. Here is a summary.

## Changes:

Updates 3rd party dependencies. Consumers of the Dockerfile will automatically have these updated dependencies installed. Users who directly run this project on this host will need to update the dependencies themselves.

**Binaries**
* `kubectl` 1.30.6 -> 1.30.10
* `helm` 3.16.2 -> 3.17.1
* `aws_cli_version` 2.17.58 -> 2.24.16
* `gcp_cli_version` 496.0.0 -> 513.0.0

## Tests
| Scenario | Provider | Kubernetes Version | Order | Cadence | Notes
|----------|----------|-------------|-----------------|-----------|-------
| 1 | Azure | 1.30 | ***** | Stable 2025.02 | Viya deployed succesfully. The readiness pod was in a Running state.
| 2 | AWS | 1.30 | ***** | Stable 2025.02 | Viya deployed succesfully. The readiness pod was in a Running state.
| 3 | GCP | 1.30 | ***** | Stable 2025.02 | Viya deployed succesfully. The readiness pod was in a Running state.