### PR TITLE
fix:  Expand categories supported by inject-sas-bases-overlays feature

### DIFF
--- a/roles/vdm/library/siteconfig_info.py
+++ b/roles/vdm/library/siteconfig_info.py
@@ -67,7 +67,7 @@ class siteConfig(object):
                 overlay = Overlay(blockName)
               except ValueError:
                 continue
-              requiredPrefix = "sas-bases/overlays/"
+              requiredPrefix = "sas-bases/"
               for entry in entries:
                 if entry.startswith(requiredPrefix):
                   self.add_overlays(overlay, entry)


### PR DESCRIPTION
This change simply narrows the scope of the `requiredPrefixes` var from `sas-bases/overlays` to just `sas-bases`, in order to support more categories of sas-bases refs for injection.  The enum already covers the possible keys.

