### PR TITLE
docs: update README to suggest release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,14 @@ Run the following commands in a terminal session:
 
 ```bash
 # clone this repository
-git clone https://github.com/sassoftware/viya4-deployment
+git clone -b <release-version-tag> https://github.com/sassoftware/viya4-deployment
 
 # move to directory
 cd viya4-deployment
 ```
+**NOTE:** To obtain a tagged release version of this project, always refer to the desired release version tag when cloning this repository as shown above. Alternatively, you can `git checkout <tag>` the tagged release version if you've already cloned the repository without a tag. 
+
+You can find the latest release version in the [releases page](https://github.com/sassoftware/viya4-deployment/releases).
 
 ### Authenticating Ansible to Access Cloud Provider
 


### PR DESCRIPTION
This PR updates to use a specific tagged release of the viya4-deployment module, instead of referencing the main branch.