### PR TITLE
fix: update how viya_admin user is added to SASAdministrator group

### DIFF
--- a/examples/sitedefault.yaml
+++ b/examples/sitedefault.yaml
@@ -24,4 +24,5 @@ config:
       objectFilter: (objectClass=inetOrgPerson)
       searchFilter: uid={0}
     sas.logon.initial.password: Password123
-config/identities/sas.identities/administrator: viya_admin
+  identities:
+    administrator: 'viya_admin'

--- a/roles/vdm/files/sitedefault.yaml
+++ b/roles/vdm/files/sitedefault.yaml
@@ -27,4 +27,5 @@ config:
       objectFilter: (objectClass=inetOrgPerson)
       searchFilter: uid={0}
     sas.logon.initial.password: Password123
-config/identities/sas.identities/administrator: viya_admin
+  identities:
+    administrator: 'viya_admin'


### PR DESCRIPTION
Relates to #647 

Updates how the viya_admin user is added to the SAS Administrators group. The old way no longer works in 2025.05+ cadences.

| Scenario| Provider | K8s version | Cadence | Notes |
|--------|---------|--------|--------|--------|
| 1 | Azure | 1.31.8 | stable 2025.05 | Successful Viya install. Logging in to SASLogon as viya_admin prompted me for admin permissions. I also verified in SASEnvironmentManager that viya_admin was in the SASAdministrators group. |
| 2 | Azure | 1.31.8 | stable 2025.04 | Same as above |
| 3 | Azure | 1.31.8 | LTS 2025.03 | Same as above | 