### PR TITLE
docs: add v9.0.0 migration guide with CSI NFS Driver (PSCLOUD-2)

### DIFF
--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -23,15 +23,11 @@ kubectl create job --from=cronjob/sas-scheduled-backup-all-sources manual-backup
 
 ###  Verify the backup job has completed successfully:
 
-
 ```bash
 kubectl get jobs \
   -l "sas.com/sas-backup-id=<backup-id>" \
   -L "sas.com/sas-backup-id,sas.com/backup-job-type,sas.com/sas-backup-job-status,sas.com/backup-persistence-status"
 ```
-
----
-
 ###  Stop the Viya Deployment
 
 Stop the SAS Viya environment using the cron job:
@@ -45,9 +41,6 @@ kubectl -n <viya-namespace> create job --from=cronjob/sas-stop-all stopdep-<date
 ```bash
 kubectl -n viya4 create job --from=cronjob/sas-stop-all stopdep-22072025
 ```
-
----
-
 ###  Delete Old NFS Provisioner Components
 
 Remove the `sas` StorageClass:
@@ -68,8 +61,7 @@ Redeploy SAS Viya using the updated DaC baseline that includes CSI NFS driver su
 
 >  **Important Note:** You do **not** need to restore from backup, as the NFS server path to the PVs remains the same. The CSI driver will reuse existing PVs and directories automatically.
 
-
-## 🔍 Post-Migration Steps
+##  Post-Migration Steps
 
 *  Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
 *  Validate **data availability** and application functionality.
@@ -82,4 +74,3 @@ Redeploy SAS Viya using the updated DaC baseline that includes CSI NFS driver su
 * The **CSI NFS driver** offers improved compatibility with newer Kubernetes versions and is the **recommended** provisioner going forward.
 * Avoid reusing the old Helm release metadata (`meta.helm.sh/*`) to prevent installation or upgrade conflicts.
 
----

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -1,20 +1,15 @@
 
-````markdown
 #  Migration Guide: NFS Subdir-External Provisioner to CSI NFS Driver
 
 This document outlines the steps required to migrate from the legacy `nfs-subdir-external-provisioner` to the CSI-based `csi-driver-nfs` in a SAS Viya 4 environment on Azure.
 
-> This guide assumes you are migrating a Viya deployment (e.g., `v8.2.1`) to a newer version (e.g., `v9.0.0`) using the latest DaC baseline that includes the `csi-driver-nfs`.
-
----
+This guide assumes you are migrating a Viya deployment (e.g., `v8.2.1`) to a newer version (e.g., `v9.0.0`) using the latest DaC baseline that includes the `csi-driver-nfs`.
 
 ##  Prerequisites
 
 - Ensure you have **cluster admin access**.
 - The **NFS server** used in the existing setup must be retained and accessible.
 - All **PVs and PVCs** should be backed up as a precaution.
-
----
 
 ##  Migration Steps
 
@@ -26,7 +21,8 @@ Trigger a manual backup of your running Viya deployment:
 kubectl create job --from=cronjob/sas-scheduled-backup-all-sources manual-backup-$(date +%s) -n <viya-namespace>
 ````
 
-Verify the backup job has completed successfully:
+###  Verify the backup job has completed successfully:
+
 
 ```bash
 kubectl get jobs \
@@ -66,25 +62,22 @@ Delete the namespace used by the legacy provisioner (typically `nfs-client`):
 kubectl delete namespace nfs-client
 ```
 
----
-
 ###  Deploy New Viya Environment with CSI Driver
 
 Redeploy SAS Viya using the updated DaC baseline that includes CSI NFS driver support.
 
 >  **Important Note:** You do **not** need to restore from backup, as the NFS server path to the PVs remains the same. The CSI driver will reuse existing PVs and directories automatically.
 
----
 
 ## 🔍 Post-Migration Steps
 
-* ✅ Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
-* 🔄 Validate **data availability** and application functionality.
-* 📝 Finalize documentation and update the `README.md` or internal documentation as needed.
+*  Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
+*  Validate **data availability** and application functionality.
+*  Finalize documentation and update the `README.md` or internal documentation as needed.
 
 ---
 
-## 📌 Notes
+##  Notes
 
 * The **CSI NFS driver** offers improved compatibility with newer Kubernetes versions and is the **recommended** provisioner going forward.
 * Avoid reusing the old Helm release metadata (`meta.helm.sh/*`) to prevent installation or upgrade conflicts.

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -21,7 +21,7 @@ Trigger a manual backup of your running Viya deployment:
 kubectl create job --from=cronjob/sas-scheduled-backup-all-sources manual-backup-$(date +%s) -n <viya-namespace>
 ````
 
-fatch the backup ID
+Fatch the backup ID
 
 ```bash
 kubectl describe job <backup-job-name> -n va-viya | grep "sas.com/sas-backup-id"
@@ -68,12 +68,12 @@ If you have redeployed SAS Viya using the updated DaC baseline that includes CSI
 However, if you have only updated the DaC baseline without redeploying Viya, you will need to manually start the Viya environment using the following command:
 
 ```bash
-kubectl -n <namespace> create job --from=cronjobs/sas-start-all startdep-<guid>
+kubectl -n <viya-namespace> create job --from=cronjob/sas-start-all startdep-<date +%s>
 ```
 
 >  **Important Note:** You do **not** need to restore from backup, as the NFS server path to the PVs remains the same. The CSI driver will reuse existing PVs and directories automatically.
 
-##  Post-Migration Steps
+###  Post-Migration Steps
 
 *  Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
 *  Validate **data availability** and application functionality.
@@ -81,7 +81,7 @@ kubectl -n <namespace> create job --from=cronjobs/sas-start-all startdep-<guid>
 
 ---
 
-##  Notes
+###  Notes
 
 * The **CSI NFS driver** offers improved compatibility with newer Kubernetes versions and is the **recommended** provisioner going forward.
 * Avoid reusing the old Helm release metadata (`meta.helm.sh/*`) to prevent installation or upgrade conflicts.

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -1,7 +1,5 @@
 
-#  Migration Guide: NFS Subdir-External Provisioner to CSI NFS Driver
-
-This document outlines the steps required to migrate from the legacy `nfs-subdir-external-provisioner` to the CSI-based `csi-driver-nfs` in a SAS Viya 4 environment on Azure.
+#  Migration Guide: v9.0.0
 
 This guide assumes you are migrating a Viya deployment (e.g., `v8.2.1`) to a newer version (e.g., `v9.0.0`) using the latest DaC baseline that includes the `csi-driver-nfs`.
 

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -21,6 +21,12 @@ Trigger a manual backup of your running Viya deployment:
 kubectl create job --from=cronjob/sas-scheduled-backup-all-sources manual-backup-$(date +%s) -n <viya-namespace>
 ````
 
+fatch the backup ID
+
+```bash
+kubectl describe job <backup-job-name> -n va-viya | grep "sas.com/sas-backup-id"
+````
+
 ###  Verify the backup job has completed successfully:
 
 ```bash
@@ -33,7 +39,7 @@ kubectl get jobs \
 Stop the SAS Viya environment using the cron job:
 
 ```bash
-kubectl -n <viya-namespace> create job --from=cronjob/sas-stop-all stopdep-<datestamp>
+kubectl -n <viya-namespace> create job --from=cronjob/sas-stop-all stopdep-<date +%s>
 ```
 
 **Example:**
@@ -57,7 +63,13 @@ kubectl delete namespace nfs-client
 
 ###  Deploy New Viya Environment with CSI Driver
 
-Redeploy SAS Viya using the updated DaC baseline that includes CSI NFS driver support.
+If you have redeployed SAS Viya using the updated DaC baseline that includes CSI NFS driver support, no additional action is required.
+
+However, if you have only updated the DaC baseline without redeploying Viya, you will need to manually start the Viya environment using the following command:
+
+```bash
+kubectl -n <namespace> create job --from=cronjobs/sas-start-all startdep-<guid>
+```
 
 >  **Important Note:** You do **not** need to restore from backup, as the NFS server path to the PVs remains the same. The CSI driver will reuse existing PVs and directories automatically.
 

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -1,0 +1,92 @@
+
+````markdown
+#  Migration Guide: NFS Subdir-External Provisioner to CSI NFS Driver
+
+This document outlines the steps required to migrate from the legacy `nfs-subdir-external-provisioner` to the CSI-based `csi-driver-nfs` in a SAS Viya 4 environment on Azure.
+
+> This guide assumes you are migrating a Viya deployment (e.g., `v8.2.1`) to a newer version (e.g., `v9.0.0`) using the latest DaC baseline that includes the `csi-driver-nfs`.
+
+---
+
+##  Prerequisites
+
+- Ensure you have **cluster admin access**.
+- The **NFS server** used in the existing setup must be retained and accessible.
+- All **PVs and PVCs** should be backed up as a precaution.
+
+---
+
+##  Migration Steps
+
+###  Backup Existing Viya Environment (Manual Trigger)
+
+Trigger a manual backup of your running Viya deployment:
+
+```bash
+kubectl create job --from=cronjob/sas-scheduled-backup-all-sources manual-backup-$(date +%s) -n <viya-namespace>
+````
+
+Verify the backup job has completed successfully:
+
+```bash
+kubectl get jobs \
+  -l "sas.com/sas-backup-id=<backup-id>" \
+  -L "sas.com/sas-backup-id,sas.com/backup-job-type,sas.com/sas-backup-job-status,sas.com/backup-persistence-status"
+```
+
+---
+
+###  Stop the Viya Deployment
+
+Stop the SAS Viya environment using the cron job:
+
+```bash
+kubectl -n <viya-namespace> create job --from=cronjob/sas-stop-all stopdep-<datestamp>
+```
+
+**Example:**
+
+```bash
+kubectl -n viya4 create job --from=cronjob/sas-stop-all stopdep-22072025
+```
+
+---
+
+###  Delete Old NFS Provisioner Components
+
+Remove the `sas` StorageClass:
+
+```bash
+kubectl delete storageclass sas
+```
+
+Delete the namespace used by the legacy provisioner (typically `nfs-client`):
+
+```bash
+kubectl delete namespace nfs-client
+```
+
+---
+
+###  Deploy New Viya Environment with CSI Driver
+
+Redeploy SAS Viya using the updated DaC baseline that includes CSI NFS driver support.
+
+>  **Important Note:** You do **not** need to restore from backup, as the NFS server path to the PVs remains the same. The CSI driver will reuse existing PVs and directories automatically.
+
+---
+
+## 🔍 Post-Migration Steps
+
+* ✅ Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
+* 🔄 Validate **data availability** and application functionality.
+* 📝 Finalize documentation and update the `README.md` or internal documentation as needed.
+
+---
+
+## 📌 Notes
+
+* The **CSI NFS driver** offers improved compatibility with newer Kubernetes versions and is the **recommended** provisioner going forward.
+* Avoid reusing the old Helm release metadata (`meta.helm.sh/*`) to prevent installation or upgrade conflicts.
+
+---

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -50,6 +50,7 @@ kubectl -n viya4 create job --from=cronjob/sas-stop-all stopdep-22072025
 ###  Delete Old NFS Provisioner Components
 
 Remove the `sas` StorageClass:
+For SAS Viya environments deployed on Google Cloud Platform (GCP), the legacy `pg-storage` StorageClass must be deleted.
 
 ```bash
 kubectl delete storageclass sas

--- a/docs/user/MigrationSteps-v9.md
+++ b/docs/user/MigrationSteps-v9.md
@@ -77,7 +77,6 @@ kubectl -n <viya-namespace> create job --from=cronjob/sas-start-all startdep-<da
 
 *  Confirm all PVCs are **bound and mounted correctly** in the new Viya deployment.
 *  Validate **data availability** and application functionality.
-*  Finalize documentation and update the `README.md` or internal documentation as needed.
 
 ---
 


### PR DESCRIPTION
The viya4-deployment (DaC) project recently updated its storage strategy, replacing the nfs-subdir-external-provisioner with the nfs.csi.k8s.io provisioner.
This PR adds a step-by-step migration guide to help transition from the legacy nfs-subdir-external-provisioner to the CSI-based csi-driver-nfs in Kubernetes environments.

