### PR TITLE
fix: respect ManageStorage flag in StorageClass creation (PSCLOUD-153)

### DIFF
--- a/roles/baseline/tasks/main.yaml
+++ b/roles/baseline/tasks/main.yaml
@@ -86,6 +86,8 @@
     file: storage-classes.yaml
   when:
     - PROVIDER == "azure"
+    - V4_CFG_MANAGE_STORAGE is defined
+    - V4_CFG_MANAGE_STORAGE|bool
   tags:
     - baseline
 


### PR DESCRIPTION
**Summary**
This PR addresses a discrepancy between the documented behavior of the V4_CFG_MANAGE_STORAGE flag and its actual implementation in Viya deployment automation.

**Root Cause:**
The current logic in baseline/tasks/main.yaml includes storage-classes.yaml based solely on the cloud provider, without checking the value of V4_CFG_MANAGE_STORAGE.

**Solution**
Update the when clause for the "Include StorageClasses" task to properly evaluate the V4_CFG_MANAGE_STORAGE flag.

