### PR TITLE
feat: set ingress-nginx chart version dynamically based on cadence version (PSCLOUD-99, PSCLOUD-158)

### DIFF
--- a/roles/baseline/tasks/ingress-nginx.yaml
+++ b/roles/baseline/tasks/ingress-nginx.yaml
@@ -27,6 +27,10 @@
     - install
     - update
   block:
+    # Set the chart version based on cadence version
+    - name: Set ingress-nginx chart version based on cadence
+      set_fact:
+        INGRESS_NGINX_CHART_VERSION: "{{ '4.12.1' if V4_CFG_CADENCE_VERSION | float <= 2025.07 else '4.13.0' }}"
     # Retrieve Kubernetes cluster version information
     - name: Retrieve K8s cluster information
       kubernetes.core.k8s_cluster_info:


### PR DESCRIPTION
set ingress-nginx chart version dynamically based on cadence version

- Added conditional logic to set INGRESS_NGINX_CHART_VERSION to 4.12.1 when
  V4_CFG_CADENCE_VERSION <= 2025.07, otherwise default to 4.13.0.
- Ensures correct chart version is used during Helm deployment based on cadence schedule.
