### PR TITLE
fix: update CONFIG-VARS.md for metric server (PSCLOUD-98)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -424,9 +424,9 @@ Kubernetes Metrics Server installation is currently only applicable for AWS EKS 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
 | METRICS_SERVER_ENABLED | Whether to deploy Metrics Server | bool | true | false | | baseline |
-| METRICS_SERVER_CHART_URL | Metrics Server Helm chart url | string | Go [here](https://charts.bitnami.com/bitnami/) for more information. | false | If an existing Metrics Server is installed, these options are ignored. | baseline |
+| METRICS_SERVER_CHART_URL | Metrics Server Helm chart url | string | Go [here](https://kubernetes-sigs.github.io/metrics-server/) for more information. | false | If an existing Metrics Server is installed, these options are ignored. | baseline |
 | METRICS_SERVER_CHART_NAME | Metrics Server Helm chart name | string | metrics-server | false | If an existing Metrics Server is installed, these options are ignored. | baseline |
-| METRICS_SERVER_CHART_VERSION | Metrics Server Helm chart version | string | 6.6.5 | false | If an existing Metrics Server is installed, these options are ignored. See [Artifact Hub](https://artifacthub.io/packages/helm/bitnami/metrics-server) to determine application version.| baseline |
+| METRICS_SERVER_CHART_VERSION | Metrics Server Helm chart version | string | 6.6.5 | false | If an existing Metrics Server is installed, these options are ignored. See [Artifact Hub](https://artifacthub.io/packages/helm/metrics-server/metrics-server) to determine application version.| baseline |
 | METRICS_SERVER_CONFIG | Metrics Server Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. | false | If an existing Metrics Server is installed, these options are ignored. | baseline |
 
 ### NFS Client


### PR DESCRIPTION
**PR Description**
This PR updates the documentation links for the Metrics Server configuration variables.

- The current documentation references the Bitnami chart for METRICS_SERVER_CHART_URL and METRICS_SERVER_CHART_VERSION.
- However, based on our IaC code ([main.yml#L29](https://github.com/sassoftware/viya4-deployment/blob/431881b8175ef8282981958ba20447a246992786/roles/baseline/defaults/main.yml#L29)), we are not using the Bitnami chart. Instead, we are pulling from the official Kubernetes SIGs Metrics Server repo:
  - Repo: https://kubernetes-sigs.github.io/metrics-server/
  - Artifact Hub: https://artifacthub.io/packages/helm/metrics-server/metrics-server

**Changes Made**
Updated CONFIG-VARS.md to replace Bitnami references with the correct Kubernetes SIGs Metrics Server chart and Artifact Hub link.

**Impact**
- No code changes, only documentation updates.
- Ensures that the documentation correctly reflects the source of the Metrics Server Helm chart being deployed.