### PR TITLE
docs: (PSCLOUD-126) Update viya4-deployment READMEs to include new SAS SpeedyStore Name

### DIFF
--- a/docs/user/SingleStore.md
+++ b/docs/user/SingleStore.md
@@ -2,38 +2,38 @@
 
 The SAS Viya platform provides an optional integration with SingleStore. SingleStore is a cloud-native database that is designed for data-intensive applications. A distributed, relational SQL database management system that features ANSI SQL support, SingleStore is known for speed in data ingest, transaction processing, and query processing.
 
-## Requirements for SAS with SingleStore
+## Requirements for SAS SpeedyStore
 
-If your SAS software order includes SAS with SingleStore, additional requirements apply to your deployment. The [_SAS Viya Platform Operations Guide_](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n0jq6u1duu7sqnn13cwzecyt475u.htm#n0qs42c42o8jjzn12ib4276fk7pb) provides detailed information about requirements for a SingleStore-enabled deployment of the SAS Viya platform.
+If your SAS software order includes SAS SpeedyStore, additional requirements apply to your deployment. The [_SAS Viya Platform Operations Guide_](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=n0jq6u1duu7sqnn13cwzecyt475u.htm#n0qs42c42o8jjzn12ib4276fk7pb) provides detailed information about requirements for a SingleStore-enabled deployment of the SAS Viya platform.
 
-## Deploying SAS with SingleStore Using SAS Viya 4 Deployment
+## Deploying SAS SpeedyStore Using SAS Viya 4 Deployment
 
-You can deploy SAS with SingleStore into a Kubernetes cluster in the following environments:
+You can deploy SAS SpeedyStore into a Kubernetes cluster in the following environments:
 - Azure Kubernetes Service (AKS) in Microsoft Azure
 - Elastic Kubernetes Service (EKS) in Amazon Web Services (AWS)
 - Google Kubernetes Engine (GKE) in Google Cloud Platform (GCP)
 - Open Source Kubernetes on your own machines
 
-## Cluster Provisioning for SAS with SingleStore
+## Cluster Provisioning for SAS SpeedyStore
 
 ### Azure Kubernetes Service (AKS) Cluster in Microsoft Azure
 
-The [SAS Viya 4 IaC for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS with SingleStore deployments.
+The [SAS Viya 4 IaC for Microsoft Azure](https://github.com/sassoftware/viya4-iac-azure) GitHub project can automatically provision the required infrastructure components that support SAS SpeedyStore deployments.
 Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-azure/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an AKS cluster that is suitable for deploying the SAS Viya platform and SingleStore.
 
 ### EKS Cluster in AWS
 
-The [SAS Viya 4 IaC for AWS](https://github.com/sassoftware/viya4-iac-aws) GitHub project can automatically provision the required infrastructure components that support SAS with SingleStore deployments.
+The [SAS Viya 4 IaC for AWS](https://github.com/sassoftware/viya4-iac-aws) GitHub project can automatically provision the required infrastructure components that support SAS SpeedyStore deployments.
 Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-aws/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an EKS cluster that is suitable for deploying the SAS Viya platform and SingleStore.
 
 ### GKE Cluster in GCP
 
-The [SAS Viya 4 IaC for GCP](https://github.com/sassoftware/viya4-iac-gcp) GitHub project can automatically provision the required infrastructure components that support SAS with SingleStore deployments.
+The [SAS Viya 4 IaC for GCP](https://github.com/sassoftware/viya4-iac-gcp) GitHub project can automatically provision the required infrastructure components that support SAS SpeedyStore deployments.
 Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-gcp/blob/main/examples/sample-input-singlestore.tfvars) for Terraform configuration values that create an GKE cluster that is suitable for deploying the SAS Viya platform and SingleStore.
 
 ### Open Source Kubernetes Cluster
 
-The [SAS Viya 4 Infrastructure as Code (IaC) for Open Source Kubernetes](https://github.com/sassoftware/viya4-iac-k8s) GitHub project can automatically provision the required infrastructure components that support SAS with SingleStore deployments.
+The [SAS Viya 4 Infrastructure as Code (IaC) for Open Source Kubernetes](https://github.com/sassoftware/viya4-iac-k8s) GitHub project can automatically provision the required infrastructure components that support SAS SpeedyStore deployments.
 Refer to the [SingleStore sample input file](https://github.com/sassoftware/viya4-iac-k8s/blob/main/examples/vsphere/sample-terraform-static-singlestore.tfvars) for Terraform configuration values that create an Open Source Kubernetes cluster that is suitable for deploying the SAS Viya platform and SingleStore.
 
 ## Customizing SingleStore Deployment Overlays
@@ -46,7 +46,7 @@ Refer to the viya4-deployment [Getting Started](https://github.com/sassoftware/v
 
 After running viya4-deployment with the setting `DEPLOY=false` in your ansible-vars.yaml file, locate the `sas-bases` directory, which is a peer to the `site-config` directory underneath your SAS Viya platform deployment's <base_dir>.
 
-Complete each step under the "SingleStore Cluster Definition" heading in the "SAS SingleStore Cluster Operator" README file in order to configure your SAS with SingleStore deployment, noting the following exceptions. The README file is located at `$deploy/sas-bases/examples/sas-singlestore/README.md` (for Markdown format) or at `$deploy/sas-bases/docs/sas_singlestore_cluster_operator.htm` (for HTML format).
+Complete each step under the "SingleStore Cluster Definition" heading in the "SAS SingleStore Cluster Operator" README file in order to configure your SAS SpeedyStore deployment, noting the following exceptions. The README file is located at `$deploy/sas-bases/examples/sas-singlestore/README.md` (for Markdown format) or at `$deploy/sas-bases/docs/sas_singlestore_cluster_operator.htm` (for HTML format).
 
 - Complete steps 1 and 2 in the "SAS SingleStore Cluster Operator" README file.
 
@@ -86,7 +86,7 @@ Complete each step under the "SingleStore Cluster Definition" heading in the "SA
 
 - Set `DEPLOY=true` in your ansible-vars.yaml file.
 
-- Run viya4-deployment with the "viya, install" tags to deploy SAS with SingleStore into your cluster.
+- Run viya4-deployment with the "viya, install" tags to deploy SAS SpeedyStore into your cluster.
 
 ### SAS Viya and SingleStore orders at LTS:2023.03 and earlier
 
@@ -94,7 +94,7 @@ Refer to the viya4-deployment [Getting Started](https://github.com/sassoftware/v
 
 After running viya4-deployment with the setting `DEPLOY=false` in your ansible-vars.yaml file, locate the `sas-bases` directory, which is a peer to the `site-config` directory underneath your SAS Viya platform deployment's <base_dir>.
 
-Complete each step under the "SingleStore Cluster Definition" heading in the "SAS SingleStore Cluster Operator" README file in order to configure your SAS with SingleStore deployment, noting the following exceptions. The README file is located at `$deploy/sas-bases/examples/sas-singlestore/README.md` (for Markdown format) or at `$deploy/sas-bases/docs/sas_singlestore_cluster_operator.htm` (for HTML format).
+Complete each step under the "SingleStore Cluster Definition" heading in the "SAS SingleStore Cluster Operator" README file in order to configure your SAS SpeedyStore deployment, noting the following exceptions. The README file is located at `$deploy/sas-bases/examples/sas-singlestore/README.md` (for Markdown format) or at `$deploy/sas-bases/docs/sas_singlestore_cluster_operator.htm` (for HTML format).
 
 - Complete steps 1 and 2 in the `sas-bases/examples/sas-singlestore/README.md` file.
 
@@ -108,4 +108,4 @@ Complete each step under the "SingleStore Cluster Definition" heading in the "SA
 
 - Complete the remaining steps from the  "SAS SingleStore Cluster Operator" README file. Then set `DEPLOY=true` in your ansible-vars.yaml file.
 
-- Run viya4-deployment with the "viya, install" tags to deploy SAS with SingleStore into your cluster.
+- Run viya4-deployment with the "viya, install" tags to deploy SAS SpeedyStore into your cluster.


### PR DESCRIPTION
(PSCLOUD-126) Update viya4-deployment READMEs to include new SAS SpeedyStore Name
The official name of 'SAS with Singlestore' changed to 'SAS SpeedyStore'