### PR TITLE
fix: adding share path logic for gcp NetApp Backend

### DIFF
--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -131,7 +131,7 @@ CSI_DRIVER_NFS_CONFIG:
     volumeBindingMode: Immediate
     parameters:
       server: "{{ V4_CFG_RWX_FILESTORE_ENDPOINT }}"
-      share: "{{ '/ontap' if STORAGE_TYPE_BACKEND == 'ontap' else ('/pvs' if PROVIDER != 'azure' else (V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') ~ '/pvs')) }}"
+      share: "{{ '/ontap' if STORAGE_TYPE_BACKEND == 'ontap' else (V4_CFG_RWX_FILESTORE_PATH if (STORAGE_TYPE_BACKEND == 'netapp' and NETAPP_VOLUME_PATH | length > 0) else ('/pvs' if PROVIDER != 'azure' else (V4_CFG_RWX_FILESTORE_PATH | replace('/$', '') ~ '/pvs'))) }}"
       subdir: ${pvc.metadata.namespace}-${pvc.metadata.name}-${pv.metadata.name}
       mountPermissions: "0777"
     mountOptions:


### PR DESCRIPTION
Infrastructure Enhancements
Added condition for NetApp storage volume path and NFS mount configuration for GCP deployments (PSCLOUD-61).
