### PR TITLE
docs: Document Contour ingress controller options (PSCLOUD-481)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -368,7 +368,7 @@ If you used [viya4-iac-aws:5.6.0](https://github.com/sassoftware/viya4-iac-aws/r
 
 ### Contour
 
-Contour is an open source ingress controller that provides dynamic configuration updates and multi-team ingress delegation while maintaining a lightweight profile. Contour support is available starting with the 2026.02 cadence release.
+Contour is an open source ingress controller that provides dynamic configuration updates. Contour support is available starting with the 2026.02 cadence release.
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -29,6 +29,7 @@ Supported configuration variables are listed in the table below.  All variables 
   - [Third-Party Tools](#third-party-tools)
     - [Cert-manager](#cert-manager)
     - [Cluster Autoscaler](#cluster-autoscaler)
+    - [Contour](#contour)
     - [EBS CSI Driver](#ebs-csi-driver)
     - [Ingress-nginx](#ingress-nginx)
     - [Metrics Server](#metrics-server)
@@ -169,7 +170,7 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_INGRESS_TYPE | The ingress controller to deploy | string | "ingress" | true | Possible values: "ingress" | baseline, viya |
+| V4_CFG_INGRESS_TYPE | The ingress controller to deploy | string | "ingress" | true | Possible values: "ingress", "contour" | baseline, viya |
 | V4_CFG_INGRESS_FQDN | FQDN to the ingress for SAS Vya installation | string | | true | | viya |
 | V4_CFG_INGRESS_MODE | Whether to create a public or private Loadbalancer endpoint | string | "public" | false | Possible values: "public", "private". Setting this option to "private" adds options to the ingress controller that create a LoadBalancer with private IP address(es) only. | baseline |
 
@@ -364,6 +365,19 @@ Cluster-autoscaler is currently only used for AWS EKS clusters. Google GKE and A
 **Cluster Autoscaler Notes:**
 
 If you used [viya4-iac-aws:5.6.0](https://github.com/sassoftware/viya4-iac-aws/releases) or newer to create your infrastructure, a cluster autoscaler account should have been created for you with a policy that is compatible with both our default versions for the `CLUSTER_AUTOSCALER_CHART_VERSION` variable. If you choose an alternative version ensure that your autoscaler account has a policy that matches the recommendation from the [kubernetes/autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#iam-policy). This note is only applicable for EKS clusters.
+
+### Contour
+
+Contour is an open source ingress controller that provides dynamic configuration updates and multi-team ingress delegation while maintaining a lightweight profile. Contour support is available starting with the 2026.02 cadence release.
+
+| Name | Description | Type | Default | Required | Notes | Tasks |
+| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+| CONTOUR_NAME | Contour Helm release name | string | contour | false | | baseline |
+| CONTOUR_NAMESPACE | Contour Helm installation namespace | string | projectcontour | false | | baseline |
+| CONTOUR_CHART_NAME | Contour Helm chart name | string | contour | false | | baseline |
+| CONTOUR_CHART_URL | Contour Helm chart URL | string | https://projectcontour.github.io/helm-charts/ | false | | baseline |
+| CONTOUR_CHART_VERSION | Contour Helm chart version | string | 0.2.1 | false | | baseline |
+| CONTOUR_CONFIG | Contour Helm values | string | See [this file](../roles/baseline/defaults/main.yml) for more information. Altering this value will affect the cluster. | false | | baseline |
 
 ### EBS CSI Driver
 

--- a/examples/ansible-vars-iac.yaml
+++ b/examples/ansible-vars-iac.yaml
@@ -20,7 +20,7 @@ V4_CFG_CR_USER: <container_registry_user>
 V4_CFG_CR_PASSWORD: <container_registry_password>
 
 ## Ingress
-V4_CFG_INGRESS_TYPE: contour
+V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_FQDN: <desired_fqdn>
 V4_CFG_TLS_MODE: full-stack # [full-stack|front-door|ingress-only|disabled]
 

--- a/examples/ansible-vars.yaml
+++ b/examples/ansible-vars.yaml
@@ -31,7 +31,7 @@ V4_CFG_CR_USER: <container_registry_user>
 V4_CFG_CR_PASSWORD: <container_registry_password>
 
 ## Ingress
-V4_CFG_INGRESS_TYPE: contour
+V4_CFG_INGRESS_TYPE: ingress
 V4_CFG_INGRESS_FQDN: <desired_fqdn>
 V4_CFG_TLS_MODE: full-stack # [full-stack|front-door|ingress-only|disabled]
 

--- a/roles/baseline/defaults/main.yml
+++ b/roles/baseline/defaults/main.yml
@@ -4,7 +4,7 @@
 ---
 V4_CFG_TLS_MODE: full-stack # other valid values are front-door, ingress-only, and disabled
 V4_CFG_RWX_FILESTORE_PATH: /export
-V4_CFG_INGRESS_TYPE: contour
+V4_CFG_INGRESS_TYPE: ingress # other valid values are contour
 V4_CFG_INGRESS_MODE: public
 V4_CFG_MANAGE_STORAGE: true
 V4_CFG_AWS_LB_SUBNETS: ""

--- a/roles/baseline/tasks/contour.yaml
+++ b/roles/baseline/tasks/contour.yaml
@@ -88,7 +88,24 @@
           disablePermitInsecure: false
           tls:
             fallback-certificate: {}
-  when: CONTOUR_CONFIG.contour.configFileContents.compression is defined
+  tags:
+    - install
+    - update
+
+# Restart Contour deployment to apply the compression configuration changes
+- name: Restart Contour deployment
+  kubernetes.core.k8s:
+    state: patched
+    kind: Deployment
+    name: "{{ CONTOUR_NAME }}"
+    namespace: "{{ CONTOUR_NAMESPACE }}"
+    kubeconfig: "{{ KUBECONFIG }}"
+    definition:
+      spec:
+        template:
+          metadata:
+            annotations:
+              kubectl.kubernetes.io/restartedAt: "{{ ansible_date_time.iso8601 }}"
   tags:
     - install
     - update

--- a/roles/vdm/tasks/cas.yaml
+++ b/roles/vdm/tasks/cas.yaml
@@ -145,7 +145,7 @@
     - install
     - uninstall
     - update
-    
+
 # Add shutdown transformer for programming-only deployments (CAS disabled)
 # This approach keeps CAS resources in the manifest (avoiding prune risks) but shuts down CAS pods
 - name: CAS - shutdown for programming-only deployment


### PR DESCRIPTION
docs: Document Contour ingress controller options (PSCLOUD-481)
fix: V4_CFG_INGRESS_TYPE default to ingress (PSCLOUD-532)