### PR TITLE
feat(enhancement): remove support for old Apigee credentials (PSCLOUD-728)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -159,6 +159,10 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 | V4_CFG_APIM_CLIENT_SECRET | APIM Client Secret | string | | true | [APIM credentials](https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) | viya |
 | V4_CFG_REPOSITORY_WAREHOUSE | Repository warehouse endpoint override | string | | false | Use `https://ses.sas.com` if your enterprise firewall or proxy blocks `ses.sas.download` due to certificate trust policies. This is passed as `--repository-warehouse` flag to the sas-orchestration container during deployment. | viya |
 
+**SAS API Access Notes:**
+
+* When creating an application in the SAS Viya Orders API portal, ensure you select the environment as **PROD(mysas)** to obtain the APIM credentials
+
 ## Container Registry Access
 
 | Name | Description | Type | Default | Required | Notes | Tasks |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -155,14 +155,9 @@ When V4_CFG_MANAGE_STORAGE is set to `true`, the `sas` and `pg-storage` storage 
 
 | Name | Description | Type | Default | Required | Notes | Tasks |
 | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
-| V4_CFG_SAS_API_KEY | SAS API Key| string | | true | [API credentials](https://developer.sas.com/guides/sas-viya-orders.html) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) (Refer Deprication note below) | viya |
-| V4_CFG_SAS_API_SECRET | SAS API Secret | string | | true | [API credentials](https://developer.sas.com/guides/sas-viya-orders.html) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started)(Refer Deprication note below) | viya |
-| V4_CFG_APIM_CLIENT_ID | APIM Client ID | string | | false | [APIM credentials](https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) | viya |
-| V4_CFG_APIM_CLIENT_SECRET | APIM Client Secret | string | | false | [APIM credentials](https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) | viya |
-| USE_APIM_CREDS | Switch to use APIM credentials instead of legacy SAS API credentials | bool | false | false | Set to `true` to use APIM credentials. Supported until April 20, 2026, after which legacy SAS API credentials will no longer work. | viya |
+| V4_CFG_APIM_CLIENT_ID | APIM Client ID | string | | true | [APIM credentials](https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) | viya |
+| V4_CFG_APIM_CLIENT_SECRET | APIM Client Secret | string | | true | [APIM credentials](https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials) can be obtained from the [SAS API Portal](https://apiportal.sas.com/get-started) | viya |
 | V4_CFG_REPOSITORY_WAREHOUSE | Repository warehouse endpoint override | string | | false | Use `https://ses.sas.com` if your enterprise firewall or proxy blocks `ses.sas.download` due to certificate trust policies. This is passed as `--repository-warehouse` flag to the sas-orchestration container during deployment. | viya |
-
-**Deprecation Notice**: `V4_CFG_SAS_API_KEY` and `V4_CFG_SAS_API_SECRET` are deprecated and will stop working after April 20, 2026. Use `V4_CFG_APIM_CLIENT_ID` and `V4_CFG_APIM_CLIENT_SECRET` instead.
 
 ## Container Registry Access
 

--- a/examples/ansible-vars-iac.yaml
+++ b/examples/ansible-vars-iac.yaml
@@ -9,8 +9,8 @@ LOADBALANCER_SOURCE_RANGES: [<desired_cidr_blocks>]
 V4_CFG_MANAGE_STORAGE: true
 
 ## SAS API Access
-V4_CFG_SAS_API_KEY: <api_client_id>
-V4_CFG_SAS_API_SECRET: <api_client_secret>
+V4_CFG_APIM_CLIENT_ID: <apim_client_id>
+V4_CFG_APIM_CLIENT_SECRET: <apim_client_secret>
 V4_CFG_ORDER_NUMBER: <order_number>
 V4_CFG_CADENCE_NAME: <cadence_name> # [lts|stable]
 V4_CFG_CADENCE_VERSION: <cadence_version>

--- a/examples/ansible-vars.yaml
+++ b/examples/ansible-vars.yaml
@@ -20,8 +20,8 @@ V4_CFG_RWX_FILESTORE_PATH: <nfs_export_path>
 V4_CFG_MANAGE_STORAGE: true
 
 ## SAS API Access
-V4_CFG_SAS_API_KEY: <api_client_id>
-V4_CFG_SAS_API_SECRET: <api_client_secret>
+V4_CFG_APIM_CLIENT_ID: <apim_client_id>
+V4_CFG_APIM_CLIENT_SECRET: <apim_client_secret>
 V4_CFG_ORDER_NUMBER: <order_number>
 V4_CFG_CADENCE_NAME: <cadence_name> # [lts|stable]
 V4_CFG_CADENCE_VERSION: <cadence_version>

--- a/examples/multi-tenancy/ansible-vars-multi-tenancy.yaml
+++ b/examples/multi-tenancy/ansible-vars-multi-tenancy.yaml
@@ -12,8 +12,8 @@ LOADBALANCER_SOURCE_RANGES: [<cluster_nat_ip>/32]
 V4_CFG_MANAGE_STORAGE: true
 
 ## SAS API Access
-V4_CFG_SAS_API_KEY: <api_client_id>
-V4_CFG_SAS_API_SECRET: <api_client_secret>
+V4_CFG_APIM_CLIENT_ID: <apim_client_id>
+V4_CFG_APIM_CLIENT_SECRET: <apim_client_secret>
 V4_CFG_ORDER_NUMBER: <order_number>
 V4_CFG_CADENCE_NAME: <cadence_name> # [lts|stable]
 V4_CFG_CADENCE_VERSION: <cadence_version>

--- a/roles/vdm/defaults/main.yaml
+++ b/roles/vdm/defaults/main.yaml
@@ -19,11 +19,8 @@ V4_CFG_CR_PASSWORD: null
 V4_CFG_CR_URL: https://cr.sas.com
 V4_CFG_CR_HOST: '{{ V4_CFG_CR_URL | regex_replace("^https?:\/\/(.*)\/?", "\1") }}'
 
-V4_CFG_SAS_API_KEY: null
-V4_CFG_SAS_API_SECRET: null
 V4_CFG_APIM_CLIENT_ID: null
 V4_CFG_APIM_CLIENT_SECRET: null
-USE_APIM_CREDS: false  # Set to true to use APIM credentials instead of legacy
 V4_CFG_REPOSITORY_WAREHOUSE: null  # Warehouse endpoint override for sas-orchestration container: ses.sas.download or ses.sas.com
 
 V4_CFG_RWX_FILESTORE_ENDPOINT: null

--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -13,7 +13,6 @@
       Please provide:
         - V4_CFG_APIM_CLIENT_ID
         - V4_CFG_APIM_CLIENT_SECRET
-      
       Obtain credentials from: https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials
   when:
     - (V4_CFG_APIM_CLIENT_ID is none or V4_CFG_APIM_CLIENT_SECRET is none)

--- a/roles/vdm/tasks/assets.yaml
+++ b/roles/vdm/tasks/assets.yaml
@@ -5,32 +5,18 @@
 # This file contains the deployment asset tasks for the vdm role.
 # It is included from main.yaml to manage deployment assets.
 
-# Validate credentials based on the selected authentication method
+# Validate APIM credentials are provided
 - name: Assets - Validate APIM credentials
   fail:
     msg: |
-      USE_APIM_CREDS is set to true, but APIM credentials are missing.
+      APIM credentials are missing.
       Please provide:
         - V4_CFG_APIM_CLIENT_ID
         - V4_CFG_APIM_CLIENT_SECRET
+      
+      Obtain credentials from: https://developer.sas.com/rest-apis/mysas/docs/getting-started/authentication#obtain-client-credentials
   when:
-    - USE_APIM_CREDS | default(false)
     - (V4_CFG_APIM_CLIENT_ID is none or V4_CFG_APIM_CLIENT_SECRET is none)
-  tags:
-    - install
-    - uninstall
-    - update
-
-- name: Assets - Validate legacy credentials
-  fail:
-    msg: |
-      USE_APIM_CREDS is set to false, but legacy credentials are missing.
-      Please provide:
-        - V4_CFG_SAS_API_KEY
-        - V4_CFG_SAS_API_SECRET
-  when:
-    - not (USE_APIM_CREDS | default(false))
-    - (V4_CFG_SAS_API_KEY is none or V4_CFG_SAS_API_SECRET is none)
   tags:
     - install
     - uninstall
@@ -76,23 +62,7 @@
     - update
 
 # Download the license file using the viya4-orders-cli
-- name: Assets - Get License (legacy credentials)
-  command:
-    # Command to download the license file
-    cmd: "{{ tmpdir.path }}/viya4-orders-cli license --file-path {{ LICENSE_DIRECTORY }} --file-name license {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
-  environment:
-    CLIENTCREDENTIALSID: "{{ V4_CFG_SAS_API_KEY | b64encode }}"
-    CLIENTCREDENTIALSSECRET: "{{ V4_CFG_SAS_API_SECRET | b64encode }}"
-  when:
-    # Only run if license is missing and using legacy credentials
-    - V4_CFG_LICENSE is none
-    - not (USE_APIM_CREDS | default(false))
-  tags:
-    - install
-    - uninstall
-    - update
-
-- name: Assets - Get License (APIM credentials)
+- name: Assets - Get License
   command:
     # Command to download the license file
     cmd: "{{ tmpdir.path }}/viya4-orders-cli license --file-path {{ LICENSE_DIRECTORY }} --file-name license {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
@@ -100,32 +70,15 @@
     APIMCLIENTCREDENTIALSID: "{{ V4_CFG_APIM_CLIENT_ID | b64encode }}"
     APIMCLIENTCREDENTIALSSECRET: "{{ V4_CFG_APIM_CLIENT_SECRET | b64encode }}"
   when:
-    # Only run if license is missing and using APIM credentials
+    # Only run if license is missing
     - V4_CFG_LICENSE is none
-    - USE_APIM_CREDS | default(false)
   tags:
     - install
     - uninstall
     - update
 
 # Download the certificates using the viya4-orders-cli
-- name: Assets - Get Certificates (legacy credentials)
-  command:
-    # Command to download the certificates
-    cmd: "{{ tmpdir.path }}/viya4-orders-cli certificates --file-path {{ LICENSE_DIRECTORY }} --file-name certs {{ V4_CFG_ORDER_NUMBER }}"
-  environment:
-    CLIENTCREDENTIALSID: "{{ V4_CFG_SAS_API_KEY | b64encode }}"
-    CLIENTCREDENTIALSSECRET: "{{ V4_CFG_SAS_API_SECRET | b64encode }}"
-  when:
-    # Only run if certs are missing and using legacy credentials
-    - V4_CFG_CERTS is none
-    - not (USE_APIM_CREDS | default(false))
-  tags:
-    - install
-    - uninstall
-    - update
-
-- name: Assets - Get Certificates (APIM credentials)
+- name: Assets - Get Certificates
   command:
     # Command to download the certificates
     cmd: "{{ tmpdir.path }}/viya4-orders-cli certificates --file-path {{ LICENSE_DIRECTORY }} --file-name certs {{ V4_CFG_ORDER_NUMBER }}"
@@ -133,33 +86,15 @@
     APIMCLIENTCREDENTIALSID: "{{ V4_CFG_APIM_CLIENT_ID | b64encode }}"
     APIMCLIENTCREDENTIALSSECRET: "{{ V4_CFG_APIM_CLIENT_SECRET | b64encode }}"
   when:
-    # Only run if certs are missing and using APIM credentials
+    # Only run if certs are missing
     - V4_CFG_CERTS is none
-    - USE_APIM_CREDS | default(false)
   tags:
     - install
     - uninstall
     - update
 
 # Download deployment assets using the viya4-orders-cli
-- name: Assets - Download (legacy credentials)
-  command:
-    # Command to download deployment assets in JSON format
-    cmd: "{{ tmpdir.path }}/viya4-orders-cli dep --file-path {{ DEPLOY_DIR }} -o json {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
-  environment:
-    CLIENTCREDENTIALSID: "{{ V4_CFG_SAS_API_KEY | b64encode }}"
-    CLIENTCREDENTIALSSECRET: "{{ V4_CFG_SAS_API_SECRET | b64encode }}"
-  when:
-    # Only run if deployment assets are missing and using legacy credentials
-    - V4_CFG_DEPLOYMENT_ASSETS is none
-    - not (USE_APIM_CREDS | default(false))
-  tags:
-    - install
-    - uninstall
-    - update
-  register: res_legacy
-
-- name: Assets - Download (APIM credentials)
+- name: Assets - Download
   command:
     # Command to download deployment assets in JSON format
     cmd: "{{ tmpdir.path }}/viya4-orders-cli dep --file-path {{ DEPLOY_DIR }} -o json {{ V4_CFG_ORDER_NUMBER }} {{ V4_CFG_CADENCE_NAME }} {{ V4_CFG_CADENCE_VERSION }}"
@@ -167,19 +102,18 @@
     APIMCLIENTCREDENTIALSID: "{{ V4_CFG_APIM_CLIENT_ID | b64encode }}"
     APIMCLIENTCREDENTIALSSECRET: "{{ V4_CFG_APIM_CLIENT_SECRET | b64encode }}"
   when:
-    # Only run if deployment assets are missing and using APIM credentials
+    # Only run if deployment assets are missing
     - V4_CFG_DEPLOYMENT_ASSETS is none
-    - USE_APIM_CREDS | default(false)
   tags:
     - install
     - uninstall
     - update
-  register: res_apim
+  register: res_download
 
 # Set the order_output fact with the JSON output from the previous task
 - name: Assets - Set assets location
   set_fact:
-    order_output: "{{ (res_legacy.stdout | default(res_apim.stdout)) | from_json }}"
+    order_output: "{{ res_download.stdout | from_json }}"
   when:
     - V4_CFG_DEPLOYMENT_ASSETS is none
   tags:


### PR DESCRIPTION
This PR removes support for the legacy Apigee portal credentials ( **_V4_CFG_SAS_API_KEY, CFG_SAS_API_SECRET_** ) from DAC, in alignment with the deprecation timeline for viya4-order-cli v2.0.1. As the CLI will no longer support old Apigee credentials after April 20, 2026, DAC now exclusively supports the new APIM credentials for SAS Viya Orders API access.

### Key changes:

- Removed all logic and configuration related to old Apigee credentials.
- Updated documentation and variable references to reflect APIM-only support.
- Ensured compatibility with viya4-order-cli v2.0.1 and later.

### Impact:
Users must now use APIM credentials when interacting with the SAS Viya Orders API. Old Apigee credentials are no longer accepted or documented.