### PR TITLE
feat: Skip cas-server and workload-orchestrator overlay for ESP only orders (PSCLOUD-1152)

### DIFF
--- a/roles/vdm/tasks/cas.yaml
+++ b/roles/vdm/tasks/cas.yaml
@@ -5,6 +5,26 @@
 # This file contains the CAS server deployment tasks for the vdm role.
 # It is included from main.yaml to manage CAS server deployment.
 
+# Check if CAS server overlay exists in sas-bases (may not exist for ESP-only orders)
+- name: CAS - check if cas-server overlay exists
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/cas-server"
+  register: cas_server_overlay
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: CAS - skip notice
+  debug:
+    msg: "CAS server overlay not found in sas-bases. Skipping CAS configuration (ESP-only or non-CAS deployment)."
+  when:
+    - not cas_server_overlay.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
 # Add overlay for CAS server base resources
 - name: CAS - base
   overlay_facts:
@@ -13,6 +33,8 @@
     existing: "{{ vdm_overlays }}"
     add:
       - { resources: overlays/cas-server }
+  when:
+    - cas_server_overlay.stat.exists
   tags:
     - install
     - uninstall
@@ -21,7 +43,8 @@
 # If user provides SSSD config, create the directory, copy the file, and add overlays
 - name: CAS - user defined sssd
   when:
-    # Only run if SSSD config is provided
+    # Only run if SSSD config is provided and CAS overlay exists
+    - cas_server_overlay.stat.exists
     - V4_CFG_SSSD is not none
   tags:
     - install
@@ -60,7 +83,8 @@
     add:
       - { transformers: cas-manage-backup.yaml, vdm: true }
   when:
-    # Only run if backup controller is enabled
+    # Only run if backup controller is enabled and CAS overlay exists
+    - cas_server_overlay.stat.exists
     - V4_CFG_CAS_ENABLE_BACKUP_CONTROLLER
   tags:
     - install
@@ -77,7 +101,8 @@
       - { resources: overlays/cas-server/auto-resources, priority: 40 }
       - { transformers: overlays/cas-server/auto-resources/remove-resources.yaml, priority: 90 }
   when:
-    # Only run if RAM or cores are not set
+    # Only run if CAS overlay exists and RAM or cores are not set
+    - cas_server_overlay.stat.exists
     - V4_CFG_CAS_RAM is none or V4_CFG_CAS_CORES is none
   tags:
     - install
@@ -93,7 +118,8 @@
     add:
       - { transformers: cas-manage-cpu-and-memory.yaml, vdm: true }
   when:
-    # Only run if both RAM and cores are set
+    # Only run if CAS overlay exists and both RAM and cores are set
+    - cas_server_overlay.stat.exists
     - V4_CFG_CAS_RAM is not none
     - V4_CFG_CAS_CORES is not none
   tags:
@@ -110,7 +136,8 @@
     add:
       - { transformers: cas-manage-workers.yaml, vdm: true }
   when:
-    # Only run if worker count is greater than 1
+    # Only run if CAS overlay exists and worker count is greater than 1
+    - cas_server_overlay.stat.exists
     - V4_CFG_CAS_WORKER_COUNT |int > 1
   tags:
     - install
@@ -125,6 +152,7 @@
     add:
       - { transformers: cas-enable-external-services.yaml, vdm: true }
   when:
+    - cas_server_overlay.stat.exists
     - V4_CFG_CAS_ENABLE_LOADBALANCER
   tags:
     - install
@@ -139,6 +167,7 @@
     add:
       - { transformers: cas-auto-restart.yaml, vdm: true, min: "2021.2" }
   when:
+    - cas_server_overlay.stat.exists
     - V4_DEPLOYMENT_OPERATOR_ENABLED
     - V4_CFG_CAS_ENABLE_AUTO_RESTART
   tags:
@@ -148,6 +177,7 @@
 
 # Add shutdown transformer for programming-only deployments (CAS disabled)
 # This approach keeps CAS resources in the manifest (avoiding prune risks) but shuts down CAS pods
+# Only applies when CAS overlay exists but user explicitly disabled CAS
 - name: CAS - shutdown for programming-only deployment
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
@@ -156,7 +186,8 @@
     add:
       - { transformers: cas-shutdown.yaml, vdm: true, priority: 100 }
   when:
-    # Only add shutdown transformer when CAS is disabled
+    # Only add shutdown transformer when CAS overlay exists but CAS is explicitly disabled
+    - cas_server_overlay.stat.exists
     - not (V4_CFG_ENABLE_CAS | default(true) | bool)
   tags:
     - install

--- a/roles/vdm/tasks/sizing.yaml
+++ b/roles/vdm/tasks/sizing.yaml
@@ -6,18 +6,19 @@
 # It is included from main.yaml to manage sizing overlays and configuration.
 
 # Add overlays for minimal sizing if the cluster node pool mode is minimal
+
+# Check if cas-server overlay exists
 - name: Sizing - check if cas-server overlay exists
   stat:
     path: "{{ DEPLOY_DIR }}/sas-bases/overlays/cas-server"
   register: cas_server_overlay_sizing
-  when:
-    - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
   tags:
     - install
     - uninstall
     - update
 
-- name: Sizing - minimal
+# Add overlays for minimal sizing with CAS
+- name: Sizing - minimal (with CAS)
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
@@ -28,13 +29,14 @@
   when:
     # Only run if minimal node pool mode is set and CAS overlay exists
     - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
-    - cas_server_overlay_sizing.stat.exists | default(false)
+    - cas_server_overlay_sizing.stat.exists
   tags:
     - install
     - uninstall
     - update
 
-- name: Sizing - minimal (no CAS)
+# Add overlays for minimal sizing without CAS
+- name: Sizing - minimal (without CAS)
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
     cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
@@ -42,8 +44,9 @@
     add:
       - { transformers: overlays/scaling/single-replica/transformer.yaml, priority: 90, min: 2021.1.1 }
   when:
+    # Only run if minimal node pool mode is set and CAS overlay does not exist
     - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
-    - not (cas_server_overlay_sizing.stat.exists | default(false))
+    - not cas_server_overlay_sizing.stat.exists
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/sizing.yaml
+++ b/roles/vdm/tasks/sizing.yaml
@@ -6,6 +6,17 @@
 # It is included from main.yaml to manage sizing overlays and configuration.
 
 # Add overlays for minimal sizing if the cluster node pool mode is minimal
+- name: Sizing - check if cas-server overlay exists
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/cas-server"
+  register: cas_server_overlay_sizing
+  when:
+    - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
+  tags:
+    - install
+    - uninstall
+    - update
+
 - name: Sizing - minimal
   overlay_facts:
     cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
@@ -15,8 +26,24 @@
       - { transformers: overlays/cas-server/require-cas-label.yaml, priority: 90, min: 2021.1.2 }
       - { transformers: overlays/scaling/single-replica/transformer.yaml, priority: 90, min: 2021.1.1 }
   when:
-    # Only run if minimal node pool mode is set
+    # Only run if minimal node pool mode is set and CAS overlay exists
     - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
+    - cas_server_overlay_sizing.stat.exists | default(false)
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: Sizing - minimal (no CAS)
+  overlay_facts:
+    cadence_name: "{{ V4_CFG_CADENCE_NAME }}"
+    cadence_number: "{{ V4_CFG_CADENCE_VERSION }}"
+    existing: "{{ vdm_overlays }}"
+    add:
+      - { transformers: overlays/scaling/single-replica/transformer.yaml, priority: 90, min: 2021.1.1 }
+  when:
+    - V4_CFG_CLUSTER_NODE_POOL_MODE == "minimal"
+    - not (cas_server_overlay_sizing.stat.exists | default(false))
   tags:
     - install
     - uninstall

--- a/roles/vdm/tasks/workload_orchestrator.yaml
+++ b/roles/vdm/tasks/workload_orchestrator.yaml
@@ -7,11 +7,33 @@
 
 # Workload Orchestrator Overlay Handling
 
+# Check if the base sas-workload-orchestrator overlay directory exists (may not exist for ESP-only orders)
+- name: Check existence of orchestrator overlay
+  stat:
+    path: "{{ DEPLOY_DIR }}/sas-bases/overlays/sas-workload-orchestrator"
+  register: orchestrator_overlay_exists
+  tags:
+    - install
+    - uninstall
+    - update
+
+- name: Workload Orchestrator - skip notice
+  debug:
+    msg: "SAS Workload Orchestrator overlay not found in sas-bases. Skipping workload orchestrator configuration."
+  when:
+    - not orchestrator_overlay_exists.stat.exists
+  tags:
+    - install
+    - uninstall
+    - update
+
 # Check if cluster-role exists in the orchestrator overlay
 - name: Check existence of orchestrator cluster-role
   stat:
     path: "{{ DEPLOY_DIR }}/sas-bases/overlays/sas-workload-orchestrator/cluster-role"
   register: orchestrator_cluster_role
+  when:
+    - orchestrator_overlay_exists.stat.exists
   tags:
     - install
     - uninstall
@@ -22,6 +44,8 @@
   stat:
     path: "{{ DEPLOY_DIR }}/sas-bases/overlays/sas-workload-orchestrator-server/cluster-role"
   register: orchestrator_server_cluster_role
+  when:
+    - orchestrator_overlay_exists.stat.exists
   tags:
     - install
     - uninstall
@@ -35,6 +59,8 @@
         if orchestrator_cluster_role.stat.exists | default(false)
         else 'overlays/sas-workload-orchestrator'
       }}
+  when:
+    - orchestrator_overlay_exists.stat.exists
   tags:
     - install
     - uninstall
@@ -51,7 +77,8 @@
         min: "2023.08"
         vdm: false
   when:
-    # Only run if workload orchestrator is enabled
+    # Only run if workload orchestrator is enabled and overlay exists
+    - orchestrator_overlay_exists.stat.exists
     - V4_WORKLOAD_ORCHESTRATOR_ENABLED
   tags:
     - install
@@ -70,6 +97,7 @@
         vdm: false
   when:
     # Only run if workload orchestrator is enabled AND server cluster-role exists
+    - orchestrator_overlay_exists.stat.exists
     - V4_WORKLOAD_ORCHESTRATOR_ENABLED
     - orchestrator_server_cluster_role.stat.exists | default(false)
   tags:
@@ -87,7 +115,8 @@
       - { transformers: examples/sas-workload-orchestrator/enable-disable/sas-workload-orchestrator-disable-patch-transformer.yaml, min: "2023.08", max: "2024.06", vdm: false }
       - { transformers: overlays/sas-workload-orchestrator/enable-disable/sas-workload-orchestrator-disable-patch-transformer.yaml, min: "2024.07", vdm: false }
   when:
-    # Only run if workload orchestrator is not enabled
+    # Only run if workload orchestrator is not enabled and overlay exists
+    - orchestrator_overlay_exists.stat.exists
     - not V4_WORKLOAD_ORCHESTRATOR_ENABLED
   tags:
     - install
@@ -97,7 +126,8 @@
 # Remove ClusterRoleBinding and ClusterRole if uninstalling and orchestrator is enabled for recent cadence
 - name: Workload Orchestrator - Remove the ClusterRoleBinding and ClusterRole
   when:
-    # Only run if uninstalling, orchestrator is enabled, and cadence is recent
+    # Only run if uninstalling, orchestrator overlay exists, orchestrator is enabled, and cadence is recent
+    - orchestrator_overlay_exists.stat.exists
     - DEPLOY
     - V4_WORKLOAD_ORCHESTRATOR_ENABLED
     - V4_CFG_CADENCE_VERSION is version('2023.08', ">=") or V4_CFG_CADENCE_NAME|lower == "fast"


### PR DESCRIPTION
**Support ESP-only and specialized orders without CAS and Workload Orchestrator components**

**Issue**
PSCLOUD-1152: viya4-deployment fails on ESP-only orders that lack cas-server and workload-orchestrator overlays in their assets. DAC unconditionally adds these overlays, causing kustomize build failures.

**Solution**
Add conditional checks to skip overlay inclusion when they don't exist in sas-bases. Overlays are now only added if the overlay directory is actually present in the deployment assets.

**Changes**
- roles/vdm/tasks/cas.yaml: Guard all CAS tasks on cas-server overlay existence
- roles/vdm/tasks/workload_orchestrator.yaml: Handle minimal sizing with and without CAS overlay
- roles/vdm/tasks/sizing.yaml: Guard orchestrator tasks on workload-orchestrator overlay existence